### PR TITLE
修复低版本(UE5.6及之前)gameplaytag api问题

### DIFF
--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
@@ -7,6 +7,7 @@
 #include "GameplayTagsEditorModule.h"
 #include "GameplayTagsManager.h"
 #include "GameplayTagsSettings.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Misc/FileHelper.h"
 
 namespace BridgeGameplayTagOps
@@ -69,13 +70,8 @@ namespace BridgeGameplayTagOps
 
 		UGameplayTagsManager& TagsMgr = UGameplayTagsManager::Get();
 		const FGameplayTagSource* Source = TagsMgr.FindTagSource(SourceName);
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 		if (!Source || !Source->SourceTagList) return 0;
-#else
-		if (!Source) return 0;
-		UGameplayTagsSettings* TagSettings = GetMutableDefault<UGameplayTagsSettings>();
-		if (!TagSettings) return 0;
-#endif
 
 		const FString IniPath = Source->GetConfigFileName();
 		if (IniPath.IsEmpty()) return 0;
@@ -85,11 +81,7 @@ namespace BridgeGameplayTagOps
 
 		// Build the set of redirect lines that should be present.
 		TArray<FString> MissingLines;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 		for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
-#else
-		for (const FGameplayTagRedirect& R : TagSettings->GameplayTagRedirects)
-#endif
 		{
 			if (R.OldTagName.IsNone() || R.NewTagName.IsNone()) continue;
 			const FString Line = FString::Printf(
@@ -131,6 +123,9 @@ namespace BridgeGameplayTagOps
 			TEXT("EnsureSourceRedirectsPersisted: re-appended %d redirect(s) to %s"),
 			MissingLines.Num(), *IniPath);
 		return MissingLines.Num();
+#else
+		return 0;  // The serialization bug is 5.7+ only
+#endif
 	}
 
 	/** Look up a tag's primary source name (the FName the manager indexes
@@ -397,7 +392,7 @@ bool UUnrealBridgeGameplayTagLibrary::RenameGameplayTag(
 		return false;
 	}
 
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if !UE_VERSION_OLDER_THAN(5, 7, 0)
 	const bool bOk = IGameplayTagsEditorModule::Get().RenameTagInINI(OldTag, NewTag, bRenameChildren);
 #else
 	const bool bOk = IGameplayTagsEditorModule::Get().RenameTagInINI(OldTag, NewTag);
@@ -468,7 +463,7 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	};
 
 	const FGameplayTagSource* FoundSource = nullptr;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 	UGameplayTagsList* FoundList = nullptr;
 #else
 	int32 FoundSettingsIdx = INDEX_NONE;
@@ -481,32 +476,45 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 			if (!Source || !Source->SourceTagList) continue;
 			UGameplayTagsList* List = Source->SourceTagList;
 			for (int32 i = 0; i < List->GameplayTagRedirects.Num(); ++i)
 			{
 				const FGameplayTagRedirect& R = List->GameplayTagRedirects[i];
-#else
-			if (!Source) continue;
-			UGameplayTagsSettings* Settings = GetMutableDefault<UGameplayTagsSettings>();
-			if (!Settings) continue;
-			for (int32 i = 0; i < Settings->GameplayTagRedirects.Num(); ++i)
-			{
-				const FGameplayTagRedirect& R = Settings->GameplayTagRedirects[i];
-#endif
 				if (R.OldTagName == OldFName && R.NewTagName == NewFName)
 				{
 					FoundSource = Source;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 					FoundList = List;
-#else
-					FoundSettingsIdx = i;
-#endif
 					FoundIdx = i;
 					break;
 				}
 			}
+#else
+			// Legacy: scan this source's ini for the matching redirect line
+			if (!Source) continue;
+			{
+				const FString SIniPath = Source->GetConfigFileName();
+				if (SIniPath.IsEmpty()) continue;
+				FString SIniText;
+				if (!FFileHelper::LoadFileToString(SIniText, *SIniPath)) continue;
+				TArray<FString> SLines;
+				SIniText.ParseIntoArrayLines(SLines);
+				const FString TargetLine = FString::Printf(
+					TEXT("+GameplayTagRedirects=(OldTagName=\"%s\",NewTagName=\"%s\")"),
+					*OldTag, *NewTag);
+				bool bFoundInSource = false;
+				for (const FString& SL : SLines)
+				{
+					FString ST = SL.TrimStartAndEnd();
+					if (ST == TargetLine) { bFoundInSource = true; break; }
+				}
+				if (!bFoundInSource) continue;
+				FoundSource = Source;
+				FoundSettingsIdx = 0;
+				FoundIdx = 0;
+			}
+#endif
 			if (FoundIdx != INDEX_NONE) break;
 		}
 		if (FoundIdx != INDEX_NONE) break;
@@ -521,10 +529,10 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	}
 
 	// 1) drop from in-memory so EnsureSourceRedirectsPersisted won't re-add it
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 	FoundList->GameplayTagRedirects.RemoveAt(FoundIdx);
 #else
-		GetMutableDefault<UGameplayTagsSettings>()->GameplayTagRedirects.RemoveAt(FoundSettingsIdx);
+	// Legacy: no in-memory singleton to update; ini strip handles persistence
 #endif
 
 	// 2) strip the matching line from the on-disk ini
@@ -598,7 +606,7 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 			if (!Source || !Source->SourceTagList) continue;
 #else
 			if (!Source) continue;
@@ -606,11 +614,8 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 			if (!SourceFilterFName.IsNone() && Source->SourceName != SourceFilterFName) continue;
 
 			const FString SourceNameStr = Source->SourceName.ToString();
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
+#if !UE_VERSION_OLDER_THAN(5, 6, 0)
 			for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
-#else
-			for (const FGameplayTagRedirect& R : GetDefault<UGameplayTagsSettings>()->GameplayTagRedirects)
-#endif
 			{
 				if (R.OldTagName.IsNone() || R.NewTagName.IsNone()) continue;
 
@@ -625,6 +630,50 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 				Entry.SourceName = SourceNameStr;
 				Result.Add(MoveTemp(Entry));
 			}
+#else
+			// Legacy: parse redirects from this source's ini file
+			{
+				const FString LIniPath = Source->GetConfigFileName();
+				if (LIniPath.IsEmpty()) continue;
+				FString LIniText;
+				if (!FFileHelper::LoadFileToString(LIniText, *LIniPath)) continue;
+				TArray<FString> LLines;
+				LIniText.ParseIntoArrayLines(LLines);
+				for (const FString& LL : LLines)
+				{
+					FString LT = LL.TrimStartAndEnd();
+					if (!LT.StartsWith(TEXT("+GameplayTagRedirects="))) continue;
+					FString OldStr, NewStr;
+					{
+						int32 OI = LT.Find(TEXT("OldTagName=\""));
+						int32 NI = LT.Find(TEXT("NewTagName=\""));
+						if (OI != INDEX_NONE)
+						{
+							int32 OStart = OI + 12; // len of "OldTagName=\""
+							int32 OEnd = LT.Find(TEXT("\""), ESearchCase::CaseSensitive, ESearchDir::FromStart, OStart);
+							if (OEnd != INDEX_NONE) OldStr = LT.Mid(OStart, OEnd - OStart);
+						}
+						if (NI != INDEX_NONE)
+						{
+							int32 NStart = NI + 12; // len of "NewTagName=\""
+							int32 NEnd = LT.Find(TEXT("\""), ESearchCase::CaseSensitive, ESearchDir::FromStart, NStart);
+							if (NEnd != INDEX_NONE) NewStr = LT.Mid(NStart, NEnd - NStart);
+						}
+					}
+					if (OldStr.IsEmpty() || NewStr.IsEmpty()) continue;
+
+					// Tags are case-sensitive (Statetree != StateTree); filter must match.
+					if (!OldTagPrefixFilter.IsEmpty()
+						&& !OldStr.StartsWith(OldTagPrefixFilter, ESearchCase::CaseSensitive)) continue;
+
+					FBridgeTagRedirectEntry Entry;
+					Entry.OldTag = MoveTemp(OldStr);
+					Entry.NewTag = MoveTemp(NewStr);
+					Entry.SourceName = SourceNameStr;
+					Result.Add(MoveTemp(Entry));
+				}
+			}
+#endif
 		}
 	}
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
@@ -69,7 +69,13 @@ namespace BridgeGameplayTagOps
 
 		UGameplayTagsManager& TagsMgr = UGameplayTagsManager::Get();
 		const FGameplayTagSource* Source = TagsMgr.FindTagSource(SourceName);
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 		if (!Source || !Source->SourceTagList) return 0;
+#else
+		if (!Source) return 0;
+		UGameplayTagsSettings* TagSettings = GetMutableDefault<UGameplayTagsSettings>();
+		if (!TagSettings) return 0;
+#endif
 
 		const FString IniPath = Source->GetConfigFileName();
 		if (IniPath.IsEmpty()) return 0;
@@ -79,7 +85,11 @@ namespace BridgeGameplayTagOps
 
 		// Build the set of redirect lines that should be present.
 		TArray<FString> MissingLines;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 		for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
+#else
+		for (const FGameplayTagRedirect& R : TagSettings->GameplayTagRedirects)
+#endif
 		{
 			if (R.OldTagName.IsNone() || R.NewTagName.IsNone()) continue;
 			const FString Line = FString::Printf(
@@ -387,7 +397,11 @@ bool UUnrealBridgeGameplayTagLibrary::RenameGameplayTag(
 		return false;
 	}
 
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 	const bool bOk = IGameplayTagsEditorModule::Get().RenameTagInINI(OldTag, NewTag, bRenameChildren);
+#else
+	const bool bOk = IGameplayTagsEditorModule::Get().RenameTagInINI(OldTag, NewTag);
+#endif
 
 	// Re-append the just-written redirect if a follow-up serialise dropped it,
 	// and any other in-memory redirects that may have gone missing.
@@ -454,7 +468,11 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	};
 
 	const FGameplayTagSource* FoundSource = nullptr;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 	UGameplayTagsList* FoundList = nullptr;
+#else
+	int32 FoundSettingsIdx = INDEX_NONE;
+#endif
 	int32 FoundIdx = INDEX_NONE;
 
 	for (EGameplayTagSourceType Type : WritableTypes)
@@ -463,15 +481,28 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 			if (!Source || !Source->SourceTagList) continue;
 			UGameplayTagsList* List = Source->SourceTagList;
 			for (int32 i = 0; i < List->GameplayTagRedirects.Num(); ++i)
 			{
 				const FGameplayTagRedirect& R = List->GameplayTagRedirects[i];
+#else
+			if (!Source) continue;
+			UGameplayTagsSettings* Settings = GetMutableDefault<UGameplayTagsSettings>();
+			if (!Settings) continue;
+			for (int32 i = 0; i < Settings->GameplayTagRedirects.Num(); ++i)
+			{
+				const FGameplayTagRedirect& R = Settings->GameplayTagRedirects[i];
+#endif
 				if (R.OldTagName == OldFName && R.NewTagName == NewFName)
 				{
 					FoundSource = Source;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 					FoundList = List;
+#else
+					FoundSettingsIdx = i;
+#endif
 					FoundIdx = i;
 					break;
 				}
@@ -490,7 +521,11 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	}
 
 	// 1) drop from in-memory so EnsureSourceRedirectsPersisted won't re-add it
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 	FoundList->GameplayTagRedirects.RemoveAt(FoundIdx);
+#else
+		GetMutableDefault<UGameplayTagsSettings>()->GameplayTagRedirects.RemoveAt(FoundSettingsIdx);
+#endif
 
 	// 2) strip the matching line from the on-disk ini
 	const FString IniPath = FoundSource->GetConfigFileName();
@@ -563,11 +598,19 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 			if (!Source || !Source->SourceTagList) continue;
+#else
+			if (!Source) continue;
+#endif
 			if (!SourceFilterFName.IsNone() && Source->SourceName != SourceFilterFName) continue;
 
 			const FString SourceNameStr = Source->SourceName.ToString();
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
 			for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
+#else
+			for (const FGameplayTagRedirect& R : GetDefault<UGameplayTagsSettings>()->GameplayTagRedirects)
+#endif
 			{
 				if (R.OldTagName.IsNone() || R.NewTagName.IsNone()) continue;
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayTagLibrary.cpp
@@ -69,7 +69,7 @@ namespace BridgeGameplayTagOps
 
 		UGameplayTagsManager& TagsMgr = UGameplayTagsManager::Get();
 		const FGameplayTagSource* Source = TagsMgr.FindTagSource(SourceName);
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 		if (!Source || !Source->SourceTagList) return 0;
 #else
 		if (!Source) return 0;
@@ -85,7 +85,7 @@ namespace BridgeGameplayTagOps
 
 		// Build the set of redirect lines that should be present.
 		TArray<FString> MissingLines;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 		for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
 #else
 		for (const FGameplayTagRedirect& R : TagSettings->GameplayTagRedirects)
@@ -468,7 +468,7 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	};
 
 	const FGameplayTagSource* FoundSource = nullptr;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 	UGameplayTagsList* FoundList = nullptr;
 #else
 	int32 FoundSettingsIdx = INDEX_NONE;
@@ -481,7 +481,7 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 			if (!Source || !Source->SourceTagList) continue;
 			UGameplayTagsList* List = Source->SourceTagList;
 			for (int32 i = 0; i < List->GameplayTagRedirects.Num(); ++i)
@@ -498,7 +498,7 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 				if (R.OldTagName == OldFName && R.NewTagName == NewFName)
 				{
 					FoundSource = Source;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 					FoundList = List;
 #else
 					FoundSettingsIdx = i;
@@ -521,7 +521,7 @@ bool UUnrealBridgeGameplayTagLibrary::RemoveGameplayTagRedirect(
 	}
 
 	// 1) drop from in-memory so EnsureSourceRedirectsPersisted won't re-add it
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 	FoundList->GameplayTagRedirects.RemoveAt(FoundIdx);
 #else
 		GetMutableDefault<UGameplayTagsSettings>()->GameplayTagRedirects.RemoveAt(FoundSettingsIdx);
@@ -598,7 +598,7 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 		TagsMgr.FindTagSourcesWithType(Type, Sources);
 		for (const FGameplayTagSource* Source : Sources)
 		{
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 			if (!Source || !Source->SourceTagList) continue;
 #else
 			if (!Source) continue;
@@ -606,7 +606,7 @@ TArray<FBridgeTagRedirectEntry> UUnrealBridgeGameplayTagLibrary::ListGameplayTag
 			if (!SourceFilterFName.IsNone() && Source->SourceName != SourceFilterFName) continue;
 
 			const FString SourceNameStr = Source->SourceName.ToString();
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 6
 			for (const FGameplayTagRedirect& R : Source->SourceTagList->GameplayTagRedirects)
 #else
 			for (const FGameplayTagRedirect& R : GetDefault<UGameplayTagsSettings>()->GameplayTagRedirects)

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -41,6 +41,7 @@ These remain callable on 5.4 — the macro picks the right code path internally.
 | `UnrealBridgeAnimLibrary::SetAnimStateDefault` | `UAnimStateEntryNode::GetOutputPin()` | walk `Entry->Pins[]` for the first `EGPD_Output` pin |
 | `UnrealBridgeGameplayAbilityLibrary::GetGameplayAbilityBlueprintInfo` and `ListGameplayAbilitiesByTag` | `UGameplayAbility::GetAssetTags()` | read legacy `CDO->AbilityTags` field |
 | `UnrealBridgeBlueprintLibrary::GetPIENodeCoverage` | `FKismetDebugUtilities::FindSourceNodeForCodeLocation` const-correctness | `const_cast<UFunction*>(Func)` |
+| `UnrealBridgeGameplayTagLibrary` — `EnsureSourceRedirectsPersisted`, `RenameGameplayTag`, `RemoveGameplayTagRedirect`, `ListGameplayTagRedirects` | 5.5 lacks `UGameplayTagsList::GameplayTagRedirects` (on `UGameplayTagsSettings` only); `RenameTagInINI` 3-arg overload added in 5.7 | `!UE_VERSION_OLDER_THAN(5, 6, 0)`: use `SourceTagList->GameplayTagRedirects`; legacy: parse per-source `+GameplayTagRedirects=` lines from disk ini. `RenameTagInINI` gated at `!UE_VERSION_OLDER_THAN(5, 7, 0)` for the `bRenameChildren` parameter |
 
 ## How the gate macro works
 
@@ -67,9 +68,11 @@ python tools/build_matrix.py --only 5.7  # only 5.7
 
 Last verified versions:
 - UE 5.4 (point release: 5.4.4)
+- UE 5.5 (point release: 5.5.4)
+- UE 5.6 (point release: 5.6.1)
 - UE 5.7 (point release: 5.7.1)
 
-5.2 / 5.3 / 5.5 / 5.6 are unverified — likely work for the 5.4+ tier
+5.2 / 5.3 / are unverified — likely work for the 5.4+ tier
 (everything except items in the tables above) but the matrix has not been
 exercised against them.
 


### PR DESCRIPTION
使用UE 5.5.4编译报错：
`
[33/56] Compile [x64] UnrealBridgeGameplayTagLibrary.cpp
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(82): error C2039: "GameplayTagRedirects": 不是 "UGameplayTagsList" 的成员
D:\Code\UE_5.5\Engine\Source\Runtime\GameplayTags\Classes\GameplayTagsSettings.h(34): note: 参见“UGameplayTagsList”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(82): error C2530: “R”: 必须初始化引用
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(82): error C2143: 语法错误: 缺少“;”(在“:”的前面)
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(82): error C2143: 语法错误: 缺少“;”(在“)”的前面)
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(390): error C2660: “IGameplayTagsEditorModule::RenameTagInINI”: 函数不接受 3 个参数
D:\Code\UE_5.5\Engine\Plugins\Editor\GameplayTagsEditor\Source\GameplayTagsEditor\Public\GameplayTagsEditorModule.h(55): note: 参见“IGameplayTagsEditorModule::RenameTagInINI”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(390): note: 尝试匹配参数列表“(const FString, const FString, bool)”时
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(468): error C2039: "GameplayTagRedirects": 不是 "UGameplayTagsList" 的成员
D:\Code\UE_5.5\Engine\Source\Runtime\GameplayTags\Classes\GameplayTagsSettings.h(34): note: 参见“UGameplayTagsList”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(470): error C2039: "GameplayTagRedirects": 不是 "UGameplayTagsList" 的成员
D:\Code\UE_5.5\Engine\Source\Runtime\GameplayTags\Classes\GameplayTagsSettings.h(34): note: 参见“UGameplayTagsList”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(470): error C2530: “R”: 必须初始化引用
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(493): error C2039: "GameplayTagRedirects": 不是 "UGameplayTagsList" 的成员
D:\Code\UE_5.5\Engine\Source\Runtime\GameplayTags\Classes\GameplayTagsSettings.h(34): note: 参见“UGameplayTagsList”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(570): error C2039: "GameplayTagRedirects": 不是 "UGameplayTagsList" 的成员
D:\Code\UE_5.5\Engine\Source\Runtime\GameplayTags\Classes\GameplayTagsSettings.h(34): note: 参见“UGameplayTagsList”的声明
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(570): error C2530: “R”: 必须初始化引用
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(570): error C2143: 语法错误: 缺少“;”(在“:”的前面)
D:\Code\Programs\UE\ARPG 5.5\Plugins\UnrealBridge\Source\UnrealBridge\Private\UnrealBridgeGameplayTagLibrary.cpp(570): error C2143: 语法错误: 缺少“;”(在“)”的前面)
`

原因是

1. GameplayTagRedirects在5.5及之前的版本在UGameplayTagsSettings中声明，而5.6之后是在UGameplayTagsList声明
2. RenameTagInINI参数在5.5及之前只有两个

解决方法：

根据引擎版本不同调用不同的API