### PR TITLE
Fix cancellation for timed-out GameThread work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ action automatically. The caller must read the dialog semantics and act with
 the returned `snapshot_id`; this prevents both blind confirmation and a stale
 action landing on a different dialog.
 
+Exec and modal GameThread work share a cancellable lifecycle. If the server-side
+deadline expires while work is still queued, the response reports `cancelled before execution`
+and a later ticker/task-graph consumer cannot run the body. If the GameThread already claimed
+the work, it is not safely retractable; the response reports `already started and outcome is unknown`
+instead of claiming a successful cancellation. Shutdown first closes a shared admission gate,
+uses the same queued cancellation path, and drains tracked worker/GameThread closures before
+module unload; each result/event therefore has exactly one terminal publisher.
+
 ### Discovery Protocol
 UDP discovery uses LAN multicast on `239.255.42.99:9876` plus a parallel local-loopback probe to `127.0.0.1:9876`. Both carry the same request id and responses are de-duplicated by editor PID. This preserves LAN discovery while avoiding dependence on Windows multicast loopback. Multiple editors can bind via `SO_REUSEADDR`.
 - Probe (client → group): `{"v":1, "type":"probe", "request_id":"<uuid>", "filter":{"project":"<name|path|*>"}}`

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeCancellableWorkTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeCancellableWorkTests.cpp
@@ -1,0 +1,292 @@
+#include "Misc/AutomationTest.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "UnrealBridgeCancellableWork.h"
+#include "UnrealBridgeServer.h"
+#include "SocketSubsystem.h"
+#include "Misc/ScopeExit.h"
+
+/**
+ * Automation 只读访问 Server lifecycle 计数，不改变生产行为。
+ * Automation-only read access to Server lifecycle counters; it does not change production behavior.
+ */
+class FUnrealBridgeServerTestAccessor
+{
+public:
+	static int32 GetActiveClientCount(const FUnrealBridgeServer& Server)
+	{
+		return Server.ActiveClients.GetValue();
+	}
+
+	static int32 GetTrackedWorkerCount(const FUnrealBridgeServer& Server)
+	{
+		return Server.ClientWorkerTasks.Num();
+	}
+
+	static bool EnqueueExec(
+		FUnrealBridgeServer& Server,
+		TFunction<void()>&& Body,
+		bool bCancelBeforeConsume,
+		const FString& RequestId)
+	{
+		return Server.EnqueueExecForTesting(MoveTemp(Body), bCancelBeforeConsume, RequestId);
+	}
+
+	static void TickExecQueue(FUnrealBridgeServer& Server)
+	{
+		Server.TickConsumeQueue(0.0f);
+	}
+};
+
+namespace UnrealBridgeCancellableWorkTests
+{
+	using FIntWork = TUnrealBridgeCancellableWork<int32>;
+
+	int32 StateValue(EUnrealBridgeWorkState State)
+	{
+		return static_cast<int32>(State);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeCancelledWorkSkipsLateConsumerTest,
+	"UnrealBridge.Server.CancellableWork.CancelledWorkSkipsLateConsumer",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeCancelledWorkSkipsLateConsumerTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeCancellableWorkTests;
+	(void)Parameters;
+
+	int32 SideEffectCount = 0;
+	TFunction<int32()> Body = [&SideEffectCount]()
+	{
+		++SideEffectCount;
+		return 42;
+	};
+	TSharedPtr<FIntWork, ESPMode::ThreadSafe> Work =
+		MakeShared<FIntWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	TestTrue(TEXT("queued cancellation wins"), Work->TryCancel(-7, ObservedState));
+	TestEqual(TEXT("cancel observes terminal state"), StateValue(ObservedState),
+		StateValue(EUnrealBridgeWorkState::Cancelled));
+	TestFalse(TEXT("late consumer cannot claim cancelled work"), Work->TryExecute());
+	TestEqual(TEXT("cancelled work has no late side effect"), SideEffectCount, 0);
+	TestEqual(TEXT("state remains cancelled"), StateValue(Work->GetState()),
+		StateValue(EUnrealBridgeWorkState::Cancelled));
+
+	TestTrue(TEXT("cancellation publishes one result"), Work->WaitFor(FTimespan::Zero()));
+	if (Work->WaitFor(FTimespan::Zero()))
+	{
+		TestEqual(TEXT("published cancellation result is stable"), Work->GetResult(), -7);
+	}
+
+	EUnrealBridgeWorkState SecondObservedState = EUnrealBridgeWorkState::Queued;
+	TestFalse(TEXT("terminal cancellation cannot publish twice"),
+		Work->TryCancel(-9, SecondObservedState));
+	TestEqual(TEXT("second cancellation observes first terminal state"),
+		StateValue(SecondObservedState), StateValue(EUnrealBridgeWorkState::Cancelled));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeRunningWorkCannotBeCancelledTest,
+	"UnrealBridge.Server.CancellableWork.RunningWorkCannotBeCancelled",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeRunningWorkCannotBeCancelledTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeCancellableWorkTests;
+	(void)Parameters;
+
+	TSharedPtr<FIntWork, ESPMode::ThreadSafe> Work;
+	bool bCancellationWon = true;
+	EUnrealBridgeWorkState StateSeenInsideBody = EUnrealBridgeWorkState::Queued;
+	TFunction<int32()> Body = [&Work, &bCancellationWon, &StateSeenInsideBody]()
+	{
+		// body 内的显式尝试稳定模拟 deadline 在 consumer claim 后到达。
+		// An explicit in-body attempt deterministically models a deadline arriving after consumer claim.
+		bCancellationWon = Work->TryCancel(-1, StateSeenInsideBody);
+		return 42;
+	};
+	Work = MakeShared<FIntWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+	TestTrue(TEXT("consumer claims and executes queued work"), Work->TryExecute());
+	TestFalse(TEXT("running work cannot be relabelled cancelled"), bCancellationWon);
+	TestEqual(TEXT("deadline observes running"), StateValue(StateSeenInsideBody),
+		StateValue(EUnrealBridgeWorkState::Running));
+	TestEqual(TEXT("successful body reaches completed"), StateValue(Work->GetState()),
+		StateValue(EUnrealBridgeWorkState::Completed));
+	TestTrue(TEXT("completed work publishes its result"), Work->WaitFor(FTimespan::Zero()));
+	if (Work->WaitFor(FTimespan::Zero()))
+	{
+		TestEqual(TEXT("completed result remains authoritative"), Work->GetResult(), 42);
+	}
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	TestFalse(TEXT("completed work cannot be cancelled"), Work->TryCancel(-2, ObservedState));
+	TestEqual(TEXT("post-completion cancellation observes completed"), StateValue(ObservedState),
+		StateValue(EUnrealBridgeWorkState::Completed));
+	TestFalse(TEXT("completed work cannot execute twice"), Work->TryExecute());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeAdmissionGateRejectsAfterCloseTest,
+	"UnrealBridge.Server.CancellableWork.AdmissionGateRejectsAfterClose",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeAdmissionGateRejectsAfterCloseTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	FUnrealBridgeWorkAdmissionGate Gate;
+	int32 AdmissionCount = 0;
+	TestFalse(TEXT("closed gate rejects initial work"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+
+	Gate.Open();
+	TestTrue(TEXT("open gate admits registration"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+	Gate.Close();
+	TestFalse(TEXT("closed shutdown gate rejects trailing work"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+	TestEqual(TEXT("only pre-shutdown callback ran"), AdmissionCount, 1);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeCancelledBacklogDrainsBeforeLiveWorkTest,
+	"UnrealBridge.Server.CancellableWork.CancelledBacklogDrainsBeforeLiveWork",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeCancelledBacklogDrainsBeforeLiveWorkTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Server =
+		MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
+	if (!TestTrue(TEXT("test server starts for production ticker coverage"), Server->Start(0)))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		if (Server->IsRunning())
+		{
+			Server->Stop();
+		}
+	};
+
+	int32 CancelledSideEffects = 0;
+	int32 LiveSideEffects = 0;
+	for (int32 Index = 0; Index < 3; ++Index)
+	{
+		TFunction<void()> Body = [&CancelledSideEffects]()
+		{
+			++CancelledSideEffects;
+		};
+		TestTrue(TEXT("cancelled backlog item entered the production queue"),
+			FUnrealBridgeServerTestAccessor::EnqueueExec(
+				*Server, MoveTemp(Body), true, FString::Printf(TEXT("cancelled-%d"), Index)));
+	}
+
+	TFunction<void()> LiveBody = [&LiveSideEffects]()
+	{
+		++LiveSideEffects;
+	};
+	TestTrue(TEXT("live item entered behind cancelled tombstones"),
+		FUnrealBridgeServerTestAccessor::EnqueueExec(
+			*Server, MoveTemp(LiveBody), false, TEXT("live")));
+
+	FUnrealBridgeServerTestAccessor::TickExecQueue(*Server);
+	TestEqual(TEXT("cancelled production backlog produced no side effects"), CancelledSideEffects, 0);
+	TestEqual(TEXT("production ticker reached one live body in the same drain"), LiveSideEffects, 1);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeStopDrainsStragglingWorkerTest,
+	"UnrealBridge.Server.CancellableWork.StopDrainsStragglingWorker",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeStopDrainsStragglingWorkerTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Server =
+		MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
+	if (!TestTrue(TEXT("test server starts on an ephemeral port"), Server->Start(0)))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		if (Server->IsRunning())
+		{
+			Server->Stop();
+		}
+	};
+
+	ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+	if (!TestNotNull(TEXT("socket subsystem is available"), SocketSubsystem))
+	{
+		return false;
+	}
+	FSocket* ClientSocket = SocketSubsystem->CreateSocket(
+		NAME_Stream, TEXT("UnrealBridge shutdown automation client"), false);
+	if (!TestNotNull(TEXT("client socket was created"), ClientSocket))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		ClientSocket->Close();
+		SocketSubsystem->DestroySocket(ClientSocket);
+	};
+
+	TSharedRef<FInternetAddr> Address = SocketSubsystem->CreateInternetAddr();
+	bool bValidAddress = false;
+	Address->SetIp(TEXT("127.0.0.1"), bValidAddress);
+	Address->SetPort(Server->GetBoundPort());
+	TestTrue(TEXT("loopback address is valid"), bValidAddress);
+	if (!TestTrue(TEXT("client connects to the test server"), ClientSocket->Connect(*Address)))
+	{
+		return false;
+	}
+
+	// 只发送 frame header，让真实 worker 阻塞在 payload recv；Stop 必须关 socket 并等待 graph event。
+	// Send only a frame header so the real worker blocks in payload recv; Stop must close it and wait for its graph event.
+	const uint8 Header[4] = { 0, 0, 0, 32 };
+	int32 BytesSent = 0;
+	TestTrue(TEXT("partial request header was sent"),
+		ClientSocket->Send(Header, static_cast<int32>(UE_ARRAY_COUNT(Header)), BytesSent));
+	TestEqual(TEXT("full frame header was sent"), BytesSent,
+		static_cast<int32>(UE_ARRAY_COUNT(Header)));
+
+	const double AcceptDeadline = FPlatformTime::Seconds() + 2.0;
+	while (FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server) == 0
+		&& FPlatformTime::Seconds() < AcceptDeadline)
+	{
+		FPlatformProcess::Sleep(0.001f);
+	}
+	TestEqual(TEXT("one straggling worker is tracked before shutdown"),
+		FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server), 1);
+
+	Server->Stop();
+	TestEqual(TEXT("Stop waits for worker closure completion"),
+		FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server), 0);
+	TestEqual(TEXT("Stop releases all tracked graph events"),
+		FUnrealBridgeServerTestAccessor::GetTrackedWorkerCount(*Server), 0);
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeCancellableWork.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeCancellableWork.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/Event.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/ScopeLock.h"
+
+/**
+ * 可取消 work item 的生命周期；只有 queued 可以进入 running 或 cancelled。
+ * Lifecycle for cancellable work; only queued work may become running or cancelled.
+ */
+enum class EUnrealBridgeWorkState : uint8
+{
+	Queued,
+	Running,
+	Cancelled,
+	Completed,
+};
+
+/**
+ * 串行化 Server shutdown 与新 work 的注册；Close 返回后任何 callback 都不能再进入。
+ * Serializes Server shutdown against new work registration; no callback can enter after Close returns.
+ */
+class FUnrealBridgeWorkAdmissionGate final
+{
+public:
+	/** 开放新一轮 Server admission。 / Open admission for a new Server run. */
+	void Open()
+	{
+		FScopeLock Lock(&GateLock);
+		bOpen = true;
+	}
+
+	/** 关闭 admission，并等待已经进入的注册 callback 离开。 / Close admission and wait for entered callbacks to leave. */
+	void Close()
+	{
+		FScopeLock Lock(&GateLock);
+		bOpen = false;
+	}
+
+	/**
+	 * 只在 gate 开放时、持锁执行注册 callback，使 enqueue/task registration 与 Close 原子排序。
+	 * Run registration under the gate lock only while open, atomically ordering enqueue/task registration with Close.
+	 */
+	template <typename CallbackType>
+	bool TryAdmit(CallbackType&& Callback)
+	{
+		FScopeLock Lock(&GateLock);
+		if (!bOpen)
+		{
+			return false;
+		}
+		Forward<CallbackType>(Callback)();
+		return true;
+	}
+
+	/** 返回当前 admission 状态。 / Return the current admission state. */
+	bool IsOpen() const
+	{
+		FScopeLock Lock(&GateLock);
+		return bOpen;
+	}
+
+private:
+	mutable FCriticalSection GateLock;
+	bool bOpen = false;
+};
+
+/**
+ * 在 worker 与 GameThread 之间唯一拥有 work 状态、result 和 completion event。
+ * Sole owner of work state, result, and completion event across worker/GameThread.
+ *
+ * 同一把锁使状态转换与 result 发布成为不可分割的观测边界；body 在锁外执行，
+ * 因此 timeout 可以观察 running 并明确报告结果未知，而不会把已开始的动作误报为已取消。
+ * One lock makes state transition and result publication a single observation boundary. The body
+ * runs outside the lock so a timeout can observe running and report an unknown outcome without
+ * falsely claiming that already-started work was cancelled.
+ */
+template <typename TResult>
+class TUnrealBridgeCancellableWork final
+{
+public:
+	explicit TUnrealBridgeCancellableWork(TFunction<TResult()>&& InBody)
+		: Body(MoveTemp(InBody))
+		, CompletionEvent(FPlatformProcess::GetSynchEventFromPool(true))
+	{
+		check(CompletionEvent != nullptr);
+	}
+
+	~TUnrealBridgeCancellableWork()
+	{
+		if (CompletionEvent != nullptr)
+		{
+			FPlatformProcess::ReturnSynchEventToPool(CompletionEvent);
+			CompletionEvent = nullptr;
+		}
+	}
+
+	TUnrealBridgeCancellableWork(const TUnrealBridgeCancellableWork&) = delete;
+	TUnrealBridgeCancellableWork& operator=(const TUnrealBridgeCancellableWork&) = delete;
+
+	/**
+	 * 仅当状态仍为 queued 时执行 body；晚到的 consumer 会观察 cancelled 并跳过。
+	 * Execute only while queued; a late consumer observes cancelled and skips the body.
+	 */
+	bool TryExecute()
+	{
+		{
+			FScopeLock Lock(&StateLock);
+			if (State != EUnrealBridgeWorkState::Queued)
+			{
+				return false;
+			}
+			State = EUnrealBridgeWorkState::Running;
+		}
+
+		TResult WorkResult = Body();
+
+		{
+			FScopeLock Lock(&StateLock);
+			check(State == EUnrealBridgeWorkState::Running);
+			Result.Emplace(MoveTemp(WorkResult));
+			State = EUnrealBridgeWorkState::Completed;
+		}
+		CompletionEvent->Trigger();
+		return true;
+	}
+
+	/**
+	 * 仅取消尚未开始的 queued work，并以调用方提供的结果完成等待。
+	 * Cancel only queued work and complete the wait with the caller-supplied result.
+	 *
+	 * @param CancellationResult 取消成功时发布的结果。 / Result published when cancellation wins.
+	 * @param OutObservedState 返回取消尝试结束时的权威状态。 / Authoritative state observed by the attempt.
+	 * @return true 表示 body 永远不会执行；false 表示已开始或已终止。 / True means the body can never execute.
+	 */
+	bool TryCancel(TResult&& CancellationResult, EUnrealBridgeWorkState& OutObservedState)
+	{
+		{
+			FScopeLock Lock(&StateLock);
+			if (State != EUnrealBridgeWorkState::Queued)
+			{
+				OutObservedState = State;
+				return false;
+			}
+
+			Result.Emplace(MoveTemp(CancellationResult));
+			State = EUnrealBridgeWorkState::Cancelled;
+			OutObservedState = State;
+		}
+		CompletionEvent->Trigger();
+		return true;
+	}
+
+	/** 等待 terminal result，返回 false 表示 deadline 前未完成。 / Wait for a terminal result; false means the deadline elapsed. */
+	bool WaitFor(const FTimespan& Timeout) const
+	{
+		return CompletionEvent->Wait(Timeout);
+	}
+
+	/** 返回 terminal result 的副本；调用前必须已经完成或取消。 / Return a copy of the terminal result; wait first. */
+	TResult GetResult() const
+	{
+		FScopeLock Lock(&StateLock);
+		check(Result.IsSet());
+		return Result.GetValue();
+	}
+
+	/** 返回当前权威状态。 / Return the current authoritative state. */
+	EUnrealBridgeWorkState GetState() const
+	{
+		FScopeLock Lock(&StateLock);
+		return State;
+	}
+
+private:
+	TFunction<TResult()> Body;
+	mutable FCriticalSection StateLock;
+	TOptional<TResult> Result;
+	EUnrealBridgeWorkState State = EUnrealBridgeWorkState::Queued;
+	FEvent* CompletionEvent = nullptr;
+};

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
@@ -191,7 +191,7 @@ void FUnrealBridgeModule::StartupModule()
 	}
 
 	// ---- start the TCP server -----------------------------------------
-	Server = MakeShared<FUnrealBridgeServer>();
+	Server = MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
 	FUnrealBridgeServer::FStartConfig StartCfg;
 	StartCfg.BindAddress = BindAddress;
 	StartCfg.Port = Port;
@@ -251,10 +251,10 @@ void FUnrealBridgeModule::StartupModule()
 	}
 
 	// ---- editor-ready gate --------------------------------------------
-	TWeakPtr<FUnrealBridgeServer> WeakServer = Server;
+	TWeakPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> WeakServer = Server;
 	auto OnMainFrameReady = [WeakServer](TSharedPtr<SWindow>, bool)
 	{
-		if (TSharedPtr<FUnrealBridgeServer> Pinned = WeakServer.Pin())
+		if (TSharedPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> Pinned = WeakServer.Pin())
 		{
 			Pinned->SetEditorReady(true);
 		}
@@ -267,12 +267,19 @@ void FUnrealBridgeModule::StartupModule()
 	}
 	else
 	{
-		MainFrame.OnMainFrameCreationFinished().AddLambda(OnMainFrameReady);
+		MainFrameReadyHandle = MainFrame.OnMainFrameCreationFinished().AddLambda(OnMainFrameReady);
 	}
 }
 
 void FUnrealBridgeModule::ShutdownModule()
 {
+	if (MainFrameReadyHandle.IsValid() && FModuleManager::Get().IsModuleLoaded(TEXT("MainFrame")))
+	{
+		IMainFrameModule& MainFrame = FModuleManager::GetModuleChecked<IMainFrameModule>(TEXT("MainFrame"));
+		MainFrame.OnMainFrameCreationFinished().Remove(MainFrameReadyHandle);
+		MainFrameReadyHandle.Reset();
+	}
+
 	BridgePerfSampler::Shutdown();
 	BridgePerfFrameHook::Unregister();
 	BridgeDebugState::Unregister();

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
@@ -1,4 +1,5 @@
 #include "UnrealBridgeServer.h"
+#include "UnrealBridgeCancellableWork.h"
 #include "IPythonScriptPlugin.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
@@ -31,6 +32,22 @@ namespace UnrealBridgeLimits
 	// triggering an OOM in the editor via blind SetNumUninitialized.
 	constexpr int32 MaxRequestBytes = 10 * 1024 * 1024;
 }
+
+/**
+ * exec queue 的共享 control block；worker 等待它，GameThread ticker 尝试消费它。
+ * Shared exec-queue control block waited by a worker and claimed by the GameThread ticker.
+ */
+struct FUnrealBridgeServer::FPendingExec final
+{
+	FPendingExec(TFunction<FExecResult()>&& InBody, FString InRequestId)
+		: Work(MoveTemp(InBody))
+		, RequestId(MoveTemp(InRequestId))
+	{
+	}
+
+	TUnrealBridgeCancellableWork<FExecResult> Work;
+	FString RequestId;
+};
 
 // Modal-dialog inspection and actions deliberately live outside the normal
 // Python exec queue. A Slate modal loop does not tick FTSTicker, so an exec
@@ -495,22 +512,54 @@ namespace UnrealBridgeModal
 		return MakeResult(false, TEXT(""), TEXT("unsupported modal action"), Snapshot);
 	}
 
-	bool RunOnGameThread(TFunction<TSharedPtr<FJsonObject>()>&& Work,
-		TSharedPtr<FJsonObject>& OutResult, float TimeoutSeconds = 3.0f)
+	/** GameThread wait 的权威终态。 / Authoritative outcome of a bounded GameThread wait. */
+	enum class EGameThreadWorkWaitResult : uint8
 	{
-		auto Promise = MakeShared<TPromise<TSharedPtr<FJsonObject>>, ESPMode::ThreadSafe>();
-		TFuture<TSharedPtr<FJsonObject>> Future = Promise->GetFuture();
-		AsyncTask(ENamedThreads::GameThread, [Promise, Work = MoveTemp(Work)]() mutable
+		Completed,
+		CancelledBeforeStart,
+		AlreadyRunning,
+	};
+
+	EGameThreadWorkWaitResult RunOnGameThread(
+		TFunction<TSharedPtr<FJsonObject>()>&& Body,
+		TSharedPtr<FJsonObject>& OutResult,
+		float TimeoutSeconds = 3.0f)
+	{
+		using FModalWork = TUnrealBridgeCancellableWork<TSharedPtr<FJsonObject>>;
+		TSharedPtr<FModalWork, ESPMode::ThreadSafe> Pending =
+			MakeShared<FModalWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+		AsyncTask(ENamedThreads::GameThread, [Pending]()
 		{
-			Promise->SetValue(Work());
+			// timeout 取消成功后，这个晚到 task 只会失败 claim，绝不执行 Slate body。
+			// After timeout cancellation wins, this late task can only fail its claim and never runs the Slate body.
+			Pending->TryExecute();
 		});
 
-		if (!Future.WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
+		if (Pending->WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
 		{
-			return false;
+			OutResult = Pending->GetResult();
+			return EGameThreadWorkWaitResult::Completed;
 		}
-		OutResult = Future.Get();
-		return OutResult.IsValid();
+
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		TSharedPtr<FJsonObject> CancelledResult;
+		if (Pending->TryCancel(MoveTemp(CancelledResult), ObservedState))
+		{
+			return EGameThreadWorkWaitResult::CancelledBeforeStart;
+		}
+		if (ObservedState == EUnrealBridgeWorkState::Completed)
+		{
+			// completion 与 deadline 同时发生时返回真实结果，不伪造 timeout。
+			// If completion races the deadline, return the real result instead of fabricating a timeout.
+			OutResult = Pending->GetResult();
+			return EGameThreadWorkWaitResult::Completed;
+		}
+		if (ObservedState == EUnrealBridgeWorkState::Cancelled)
+		{
+			return EGameThreadWorkWaitResult::CancelledBeforeStart;
+		}
+		return EGameThreadWorkWaitResult::AlreadyRunning;
 	}
 }
 
@@ -519,6 +568,7 @@ namespace UnrealBridgeModal
 // ─────────────────────────────────────────────────────────────
 
 FUnrealBridgeServer::FUnrealBridgeServer()
+	: WorkAdmission(MakeUnique<FUnrealBridgeWorkAdmissionGate>())
 {
 }
 
@@ -631,6 +681,7 @@ bool FUnrealBridgeServer::Start(const FStartConfig& Config)
 	});
 
 	bIsRunning = true;
+	WorkAdmission->Open();
 	UE_LOG(LogUnrealBridge, Log, TEXT("Listening on %s:%d%s"),
 		*BindAddressStr, ListenPort,
 		HasToken() ? TEXT(" (token auth enforced)") : TEXT(""));
@@ -639,19 +690,25 @@ bool FUnrealBridgeServer::Start(const FStartConfig& Config)
 
 void FUnrealBridgeServer::Stop()
 {
-	if (!bIsRunning)
+	if (!bIsRunning && !WorkAdmission->IsOpen())
 	{
 		return;
 	}
-	bIsRunning = false;
+	checkf(IsInGameThread(), TEXT("UnrealBridge Server must stop on the GameThread"));
 
-	// 1. Stop accepting new connections.
+	// 1. 先原子关闭 work admission；Close 返回后，accept/enqueue callback 均已离开。
+	// First close work admission atomically; after Close returns, accept/enqueue callbacks have left.
+	WorkAdmission->Close();
+	bIsRunning = false;
+	const FGraphEventArray WorkersToWait = ClientWorkerTasks;
+
+	// 2. Stop accepting new connections.
 	if (Listener.IsValid())
 	{
 		Listener.Reset();
 	}
 
-	// 2. Unregister GameThread ticker and editor delegates (items #11 #12).
+	// 3. Unregister GameThread ticker and editor delegates (items #11 #12).
 	if (TickHandle.IsValid())
 	{
 		FTSTicker::GetCoreTicker().RemoveTicker(TickHandle);
@@ -678,19 +735,19 @@ void FUnrealBridgeServer::Stop()
 		PieEndHandle.Reset();
 	}
 
-	// 3. Fulfill any queued execs with a shutdown error so worker threads
-	// waiting on TFuture wake up immediately.
+	// 4. 通过共同状态机取消 queued exec；gate 已关闭，所以 drain 后不能再有新 item。
+	// Cancel queued execs through the shared state machine; the closed gate prevents post-drain admission.
 	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending;
 	while (ExecQueue.Dequeue(Pending) && Pending.IsValid())
 	{
-		FExecResult R;
-		R.bSuccess = false;
-		R.Error = TEXT("server shutting down");
-		Pending->Promise.SetValue(MoveTemp(R));
+		FExecResult ShutdownResult;
+		ShutdownResult.bSuccess = false;
+		ShutdownResult.Error = TEXT("server shutting down");
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		Pending->Work.TryCancel(MoveTemp(ShutdownResult), ObservedState);
 	}
 
-	// 4. Force-close active client sockets so HandleClient's RecvAll
-	// unblocks immediately instead of waiting for its 5 s idle timeout.
+	// 5. Force-close active client sockets so HandleClient's RecvAll/SendAll unblocks.
 	{
 		FScopeLock Lock(&ActiveSocketsLock);
 		for (FSocket* S : ActiveSockets)
@@ -702,26 +759,21 @@ void FUnrealBridgeServer::Stop()
 		}
 	}
 
-	// 5. Bounded wait for AsyncTask workers to drain (item #12). Beyond
-	// the deadline we log and proceed — the workers will still finish
-	// their cleanup (DestroySocket, ActiveClients.Decrement) but
-	// ShutdownModule isn't held hostage to a stuck Python exec.
-	const double Deadline = FPlatformTime::Seconds() + 3.0;
-	while (ActiveClients.GetValue() > 0 && FPlatformTime::Seconds() < Deadline)
+	// 6. Module unload 不能留下任何 plugin-owned closure。等待完整 graph event 会覆盖
+	// lambda body、capture destructor 与 bookkeeping；GameThread wait 同时泵送 modal/ping task。
+	// Module unload cannot leave plugin-owned closures behind. Waiting on graph events covers the
+	// lambda body, capture destruction, and bookkeeping while the GameThread pumps modal/ping tasks.
+	if (WorkersToWait.Num() > 0)
 	{
-		FPlatformProcess::Sleep(0.01f);
+		FTaskGraphInterface::Get().WaitUntilTasksComplete(WorkersToWait, ENamedThreads::GameThread);
 	}
-	const int32 Stragglers = ActiveClients.GetValue();
-	if (Stragglers > 0)
-	{
-		UE_LOG(LogUnrealBridge, Warning,
-			TEXT("Stop(): %d client worker(s) still active after 3s drain timeout"),
-			Stragglers);
-	}
-	else
-	{
-		UE_LOG(LogUnrealBridge, Log, TEXT("Stop(): all client workers drained cleanly"));
-	}
+	FTaskGraphInterface::Get().ProcessThreadUntilIdle(ENamedThreads::GameThread);
+	ClientWorkerTasks.Reset();
+
+	checkf(ActiveClients.GetValue() == 0,
+		TEXT("UnrealBridge client graph events completed with %d active clients"),
+		ActiveClients.GetValue());
+	UE_LOG(LogUnrealBridge, Log, TEXT("Stop(): all client workers and GameThread closures drained cleanly"));
 }
 
 bool FUnrealBridgeServer::IsRunning() const
@@ -750,48 +802,64 @@ bool FUnrealBridgeServer::IsEditorReady() const
 bool FUnrealBridgeServer::OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& ClientEndpoint)
 {
 	const FString EndpointStr = ClientEndpoint.ToString();
+	bool bAccepted = false;
 
-	// Bound concurrent clients so a runaway caller can't saturate the
-	// AsyncTask background pool and starve other editor work. When we're
-	// over capacity we return false so FTcpListener destroys the accepted
-	// socket itself — the client sees a clean connection reset rather than
-	// a silent hang.
-	const int32 Active = ActiveClients.Increment();
-	if (Active > MaxConcurrentClients)
+	// gate callback 同时完成容量检查、graph-event 注册与 task dispatch；Stop::Close
+	// 返回后不会出现“已快照 worker 列表之后才注册”的尾随 closure。
+	// The gate callback performs capacity check, graph-event registration, and dispatch together;
+	// after Stop::Close returns, no trailing closure can register after the worker snapshot.
+	const bool bAdmissionOpen = WorkAdmission->TryAdmit([this, ClientSocket, EndpointStr, &bAccepted]()
 	{
-		ActiveClients.Decrement();
-		UE_LOG(LogUnrealBridge, Warning,
-			TEXT("[conn] rejecting %s — at concurrency limit (%d/%d)"),
-			*EndpointStr, Active - 1, MaxConcurrentClients);
-		return false;
-	}
-
-	UE_LOG(LogUnrealBridge, Verbose, TEXT("[conn] accepted %s (active=%d)"), *EndpointStr, Active);
-
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, ClientSocket, EndpointStr]()
-	{
-		// Register socket so Stop() can force-close us (item #6).
+		ClientWorkerTasks.RemoveAll([](const FGraphEventRef& Task)
 		{
-			FScopeLock Lock(&ActiveSocketsLock);
-			ActiveSockets.Add(ClientSocket);
+			return !Task.IsValid() || Task->IsComplete();
+		});
+
+		const int32 Active = ActiveClients.Increment();
+		if (Active > MaxConcurrentClients)
+		{
+			ActiveClients.Decrement();
+			UE_LOG(LogUnrealBridge, Warning,
+				TEXT("[conn] rejecting %s — at concurrency limit (%d/%d)"),
+				*EndpointStr, Active - 1, MaxConcurrentClients);
+			return;
 		}
 
-		HandleClient(ClientSocket, EndpointStr);
+		UE_LOG(LogUnrealBridge, Verbose,
+			TEXT("[conn] accepted %s (active=%d)"), *EndpointStr, Active);
 
-		{
-			FScopeLock Lock(&ActiveSocketsLock);
-			ActiveSockets.Remove(ClientSocket);
-		}
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Self = AsShared();
+		FGraphEventRef WorkerTask = FFunctionGraphTask::CreateAndDispatchWhenReady(
+			[Self, ClientSocket, EndpointStr]()
+			{
+				// Register socket so Stop() can force-close us (item #6).
+				{
+					FScopeLock Lock(&Self->ActiveSocketsLock);
+					Self->ActiveSockets.Add(ClientSocket);
+				}
 
-		ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
-		if (SocketSubsystem)
-		{
-			SocketSubsystem->DestroySocket(ClientSocket);
-		}
-		ActiveClients.Decrement();
+				Self->HandleClient(ClientSocket, EndpointStr);
+
+				{
+					FScopeLock Lock(&Self->ActiveSocketsLock);
+					Self->ActiveSockets.Remove(ClientSocket);
+				}
+
+				ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+				if (SocketSubsystem)
+				{
+					SocketSubsystem->DestroySocket(ClientSocket);
+				}
+				Self->ActiveClients.Decrement();
+			},
+			TStatId(),
+			nullptr,
+			ENamedThreads::AnyBackgroundThreadNormalTask);
+		ClientWorkerTasks.Add(MoveTemp(WorkerTask));
+		bAccepted = true;
 	});
 
-	return true;
+	return bAdmissionOpen && bAccepted;
 }
 
 void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& EndpointStr)
@@ -978,8 +1046,13 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		// Together these pop the debug-mode stack and let ProcessEvent
 		// return, which unblocks the stuck Python exec, which unblocks the
 		// TCP response to the original caller.
-		AsyncTask(ENamedThreads::GameThread, []()
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
+		AsyncTask(ENamedThreads::GameThread, [ServerOwner]()
 		{
+			if (!ServerOwner->IsRunning())
+			{
+				return;
+			}
 			FKismetDebugUtilities::RequestAbortingExecution();
 			if (FSlateApplication::IsInitialized())
 			{
@@ -1015,9 +1088,10 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		TFuture<bool> ProbeFuture = Probe->GetFuture();
 		const double ProbeT0 = FPlatformTime::Seconds();
 
-		AsyncTask(ENamedThreads::GameThread, [Probe]()
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
+		AsyncTask(ENamedThreads::GameThread, [Probe, ServerOwner]()
 		{
-			Probe->SetValue(true);
+			Probe->SetValue(ServerOwner->IsRunning());
 		});
 
 		const bool bAlive = ProbeFuture.WaitFor(FTimespan::FromSeconds(ProbeTimeout));
@@ -1050,30 +1124,52 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		bool bChecked = false;
 		const bool bHasChecked = Request->TryGetBoolField(TEXT("checked"), bChecked);
 
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
 		TSharedPtr<FJsonObject> ModalResult;
-		const bool bCompleted = UnrealBridgeModal::RunOnGameThread(
-			[Command, ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked]()
-			{
-				if (Command == TEXT("modal_status"))
+		const UnrealBridgeModal::EGameThreadWorkWaitResult WaitResult =
+			UnrealBridgeModal::RunOnGameThread(
+				[ServerOwner, Command, ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked]()
 				{
-					return UnrealBridgeModal::GetStatus();
-				}
-				return UnrealBridgeModal::PerformAction(
-					ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked);
-			},
-			ModalResult);
+					// Stop 关闭 admission 后，晚到 task 只能返回 shutdown，不得触碰 Slate。
+					// After Stop closes admission, a late task may only return shutdown and must not touch Slate.
+					if (!ServerOwner->IsRunning())
+					{
+						return UnrealBridgeModal::MakeResult(
+							false, TEXT(""), TEXT("server shutting down"), UnrealBridgeModal::FModalSnapshot());
+					}
+					if (Command == TEXT("modal_status"))
+					{
+						return UnrealBridgeModal::GetStatus();
+					}
+					return UnrealBridgeModal::PerformAction(
+						ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked);
+				},
+				ModalResult);
 
-		if (bCompleted)
+		if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::Completed
+			&& ModalResult.IsValid())
 		{
 			Response = ModalResult.ToSharedRef();
 			Response->SetStringField(TEXT("id"), RequestId);
 		}
 		else
 		{
+			FString Error;
+			if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::CancelledBeforeStart)
+			{
+				Error = TEXT("GameThread did not service the modal request within 3.0s; queued modal work cancelled before execution");
+			}
+			else if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::AlreadyRunning)
+			{
+				Error = TEXT("modal request timed out after 3.0s; work already started and outcome is unknown");
+			}
+			else
+			{
+				Error = TEXT("modal request completed without a result");
+			}
 			Response->SetBoolField(TEXT("success"), false);
 			Response->SetStringField(TEXT("output"), TEXT(""));
-			Response->SetStringField(TEXT("error"),
-				TEXT("GameThread did not service the modal request within 3.0s"));
+			Response->SetStringField(TEXT("error"), Error);
 			Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
 		}
 	}
@@ -1193,40 +1289,99 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 // Python execution pipeline
 // ─────────────────────────────────────────────────────────────
 //
-// Worker threads enqueue heap-allocated FPendingExec and wait on the
-// associated TFuture. A single FTSTicker consumer on the GameThread drains
-// the queue one item per frame, guarded by bExecInFlight. This design:
-//   - Eliminates the reentrancy crash caused by AsyncTask(GameThread) being
-//     pulled off the task-graph queue during Python-triggered TaskGraph pumps.
-//   - Removes the dangling-reference / event-pool-reuse bug from the old
-//     per-request FEvent scheme: TSharedPtr<FPendingExec> keeps the promise
-//     alive until the ticker fulfills it, regardless of whether the worker
-//     has already returned a timeout to its client.
+// worker 把共享 FPendingExec control block 入队并等待；GameThread 的单一 FTSTicker
+// 每帧最多消费一项，并由 bExecInFlight 防止重入。共同状态机保证：保留 Python 的
+// 非重入 ticker 调度；timeout/shutdown/ticker 只有一个 terminal winner；ticker
+// 取到 cancelled tombstone 时不会执行 body。
+// Workers enqueue shared FPendingExec control blocks and wait. One GameThread
+// FTSTicker drains at most one item per frame under bExecInFlight. The shared
+// state machine preserves non-reentrant Python dispatch, gives timeout/shutdown/
+// ticker one terminal winner, and makes cancelled queue tombstones harmless.
 // ─────────────────────────────────────────────────────────────
 
 FUnrealBridgeServer::FExecResult FUnrealBridgeServer::EnqueueAndWaitForExec(
 	const FString& Script, float TimeoutSeconds, const FString& RequestId)
 {
-	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending = MakeShared<FPendingExec, ESPMode::ThreadSafe>();
-	Pending->Script = Script;
-	Pending->TimeoutSeconds = TimeoutSeconds;
-	Pending->RequestId = RequestId;
-
-	TFuture<FExecResult> Future = Pending->Promise.GetFuture();
-	ExecQueue.Enqueue(Pending);
-
-	const bool bReady = Future.WaitFor(FTimespan::FromSeconds(TimeoutSeconds));
-	if (!bReady)
+	TFunction<FExecResult()> Body = [this, Script]()
 	{
-		FExecResult R;
-		R.bSuccess = false;
-		R.Error = FString::Printf(TEXT("exec timeout after %.1fs"), TimeoutSeconds);
-		// Leave the promise alone — the ticker will still fulfill it later,
-		// but Pending's shared-ptr means that's safe and leaks nothing.
-		return R;
+		return DoPythonExec(Script);
+	};
+	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending =
+		MakeShared<FPendingExec, ESPMode::ThreadSafe>(MoveTemp(Body), RequestId);
+
+	const bool bEnqueued = WorkAdmission->TryAdmit([this, &Pending]()
+	{
+		ExecQueue.Enqueue(Pending);
+	});
+	if (!bEnqueued)
+	{
+		FExecResult ShutdownResult;
+		ShutdownResult.bSuccess = false;
+		ShutdownResult.Error = TEXT("server shutting down");
+		return ShutdownResult;
 	}
-	return Future.Get();
+
+	if (Pending->Work.WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
+	{
+		return Pending->Work.GetResult();
+	}
+
+	FExecResult TimeoutResult;
+	TimeoutResult.bSuccess = false;
+	TimeoutResult.Error = FString::Printf(
+		TEXT("exec timeout after %.1fs; queued work cancelled before execution"),
+		TimeoutSeconds);
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	if (Pending->Work.TryCancel(MoveTemp(TimeoutResult), ObservedState))
+	{
+		return Pending->Work.GetResult();
+	}
+	if (ObservedState == EUnrealBridgeWorkState::Completed
+		|| ObservedState == EUnrealBridgeWorkState::Cancelled)
+	{
+		// completion/shutdown 与 deadline 同时发生时返回权威 terminal result。
+		// If completion/shutdown races the deadline, return the authoritative terminal result.
+		return Pending->Work.GetResult();
+	}
+
+	FExecResult RunningResult;
+	RunningResult.bSuccess = false;
+	RunningResult.Error = FString::Printf(
+		TEXT("exec timeout after %.1fs; work already started and outcome is unknown"),
+		TimeoutSeconds);
+	return RunningResult;
 }
+
+#if WITH_DEV_AUTOMATION_TESTS
+bool FUnrealBridgeServer::EnqueueExecForTesting(
+	TFunction<void()>&& Body,
+	bool bCancelBeforeConsume,
+	const FString& RequestId)
+{
+	TFunction<FExecResult()> ExecBody = [Body = MoveTemp(Body)]() mutable
+	{
+		Body();
+		FExecResult Result;
+		Result.bSuccess = true;
+		return Result;
+	};
+	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending =
+		MakeShared<FPendingExec, ESPMode::ThreadSafe>(MoveTemp(ExecBody), RequestId);
+	const bool bEnqueued = WorkAdmission->TryAdmit([this, &Pending]()
+	{
+		ExecQueue.Enqueue(Pending);
+	});
+	if (bEnqueued && bCancelBeforeConsume)
+	{
+		FExecResult CancelledResult;
+		CancelledResult.Error = TEXT("cancelled by automation driver");
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		Pending->Work.TryCancel(MoveTemp(CancelledResult), ObservedState);
+	}
+	return bEnqueued;
+}
+#endif
 
 bool FUnrealBridgeServer::TickConsumeQueue(float /*DeltaTime*/)
 {
@@ -1239,16 +1394,27 @@ bool FUnrealBridgeServer::TickConsumeQueue(float /*DeltaTime*/)
 		return true; // belt-and-suspenders guard against ticker reentrancy
 	}
 
+	// 同一 tick 丢弃任意数量的 cancelled tombstone，但最多执行一个 Python body。
+	// Discard any number of cancelled tombstones in this tick, but execute at most one Python body.
 	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending;
-	if (!ExecQueue.Dequeue(Pending) || !Pending.IsValid())
+	while (ExecQueue.Dequeue(Pending))
 	{
-		return true;
-	}
+		if (!Pending.IsValid())
+		{
+			continue;
+		}
 
-	bExecInFlight = true;
-	FExecResult Result = DoPythonExec(Pending->Script);
-	Pending->Promise.SetValue(MoveTemp(Result));
-	bExecInFlight = false;
+		bExecInFlight = true;
+		const bool bExecuted = Pending->Work.TryExecute();
+		bExecInFlight = false;
+		if (bExecuted)
+		{
+			return true;
+		}
+
+		UE_LOG(LogUnrealBridge, Verbose,
+			TEXT("Skipping cancelled exec id=%s"), *Pending->RequestId);
+	}
 	return true;
 }
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeModule.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeModule.h
@@ -13,6 +13,7 @@ public:
 	virtual void ShutdownModule() override;
 
 private:
-	TSharedPtr<FUnrealBridgeServer> Server;
+	TSharedPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> Server;
 	TUniquePtr<FBridgeDiscoveryService> Discovery;
+	FDelegateHandle MainFrameReadyHandle;
 };

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
@@ -6,9 +6,12 @@
 #include "Containers/Queue.h"
 #include "Containers/Ticker.h"
 #include "Async/Future.h"
+#include "Async/TaskGraphInterfaces.h"
 #include "Containers/Set.h"
 #include "Misc/ScopeLock.h"
 #include "Interfaces/IPv4/IPv4Address.h"
+
+class FUnrealBridgeWorkAdmissionGate;
 
 /**
  * TCP server that listens for incoming connections and executes Python scripts
@@ -23,7 +26,7 @@
  *   {"id":"...", "command":"modal_status"} -> active Slate modal snapshot
  *   {"id":"...", "command":"modal_action", "snapshot":"...", ...} -> guarded modal interaction
  */
-class FUnrealBridgeServer : public TSharedFromThis<FUnrealBridgeServer>
+class FUnrealBridgeServer : public TSharedFromThis<FUnrealBridgeServer, ESPMode::ThreadSafe>
 {
 public:
 	/** Configuration for Start — replaces the legacy `int32 Port` signature. */
@@ -80,6 +83,13 @@ public:
 	bool IsEditorReady() const;
 
 private:
+#if WITH_DEV_AUTOMATION_TESTS
+	friend class FUnrealBridgeServerTestAccessor;
+
+	/** 为确定性 Automation 注入不调用 Python 的 exec body。 / Inject a non-Python exec body for deterministic Automation. */
+	bool EnqueueExecForTesting(TFunction<void()>&& Body, bool bCancelBeforeConsume, const FString& RequestId);
+#endif
+
 	/** Called by FTcpListener when a new client connects. */
 	bool OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& ClientEndpoint);
 
@@ -101,18 +111,10 @@ private:
 	};
 
 	/**
-	 * A queued exec request. Heap-allocated and shared between the worker
-	 * thread (which waits on Promise's future) and the GameThread ticker
-	 * consumer (which fulfills Promise). Shared ownership guarantees no
-	 * dangling references if the worker times out before the ticker runs.
+	 * queued exec 的私有 control block；定义留在 Server.cpp，避免把调度细节暴露为公共 API。
+	 * Private queued-exec control block, defined in Server.cpp so scheduling details stay out of the public API.
 	 */
-	struct FPendingExec
-	{
-		FString Script;
-		float TimeoutSeconds = 30.0f;
-		FString RequestId;
-		TPromise<FExecResult> Promise;
-	};
+	struct FPendingExec;
 
 	/** Enqueue a script for GameThread execution and block on the future. */
 	FExecResult EnqueueAndWaitForExec(const FString& Script, float TimeoutSeconds, const FString& RequestId);
@@ -130,13 +132,19 @@ private:
 	FThreadSafeBool bIsRunning = false;
 	FThreadSafeBool bEditorReady = false;
 
-	// Exec pipeline (item #1 of server stability plan).
+	// exec admission 与 shutdown 由同一 gate 排序；Close 后 queue 不能再收到新 work。
+	// One gate orders exec admission against shutdown; no work can enter the queue after Close.
+	TUniquePtr<FUnrealBridgeWorkAdmissionGate> WorkAdmission;
 	TQueue<TSharedPtr<FPendingExec, ESPMode::ThreadSafe>, EQueueMode::Mpsc> ExecQueue;
 	FTSTicker::FDelegateHandle TickHandle;
 	bool bExecInFlight = false; // GameThread-only, no atomic needed
 
+	// client worker graph events 让 Stop 等待 closure 真正销毁，而不只是等待 raw counter 归零。
+	// Client worker graph events let Stop wait for closure destruction, not merely a raw counter reaching zero.
+	FGraphEventArray ClientWorkerTasks;
+
 	// Connection limit (item #5). Atomic because we increment/decrement from
-	// the listener thread (accept path) and the AsyncTask worker (completion).
+	// the listener thread (accept path) and the task-graph worker (completion).
 	FThreadSafeCounter ActiveClients;
 	static constexpr int32 MaxConcurrentClients = 16;
 

--- a/tools/test_cancellable_work_contract.py
+++ b/tools/test_cancellable_work_contract.py
@@ -1,0 +1,84 @@
+"""验证 exec/modal 共用可取消 work 契约。 / Verify the shared cancellable-work contract for exec/modal."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_CPP = (
+    REPO_ROOT
+    / "Plugin"
+    / "UnrealBridge"
+    / "Source"
+    / "UnrealBridge"
+    / "Private"
+    / "UnrealBridgeServer.cpp"
+)
+WORK_HEADER = SERVER_CPP.with_name("UnrealBridgeCancellableWork.h")
+GUIDE = REPO_ROOT / "CLAUDE.md"
+
+
+class CancellableWorkSourceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = SERVER_CPP.read_text(encoding="utf-8")
+        cls.work = WORK_HEADER.read_text(encoding="utf-8")
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+
+    def test_state_machine_has_only_the_four_authoritative_states(self):
+        enum_body = self.work.split(
+            "enum class EUnrealBridgeWorkState", 1
+        )[1].split("};", 1)[0]
+        for state in ("Queued", "Running", "Cancelled", "Completed"):
+            self.assertEqual(enum_body.count(state), 1)
+
+    def test_exec_and_modal_use_the_same_work_primitive(self):
+        self.assertIn(
+            "TUnrealBridgeCancellableWork<FExecResult> Work;", self.server
+        )
+        self.assertIn(
+            "using FModalWork = "
+            "TUnrealBridgeCancellableWork<TSharedPtr<FJsonObject>>;",
+            self.server,
+        )
+        self.assertGreaterEqual(self.server.count("Pending->Work.TryCancel"), 2)
+        self.assertIn("Pending->TryCancel", self.server)
+        self.assertIn("Pending->Work.TryExecute", self.server)
+        self.assertIn("Pending->TryExecute", self.server)
+
+    def test_timeout_results_distinguish_cancelled_from_running(self):
+        self.assertIn("queued work cancelled before execution", self.server)
+        self.assertIn("work already started and outcome is unknown", self.server)
+        self.assertNotIn(
+            "Leave the promise alone — the ticker will still fulfill it later",
+            self.server,
+        )
+
+    def test_timeout_contract_is_documented_for_callers(self):
+        self.assertIn("cancelled before execution", self.guide)
+        self.assertIn("already started and outcome is unknown", self.guide)
+
+    def test_shutdown_closes_admission_and_drains_plugin_closures(self):
+        self.assertGreaterEqual(self.server.count("WorkAdmission->TryAdmit"), 2)
+        self.assertIn("WorkAdmission->Close();", self.server)
+        self.assertIn("WaitUntilTasksComplete", self.server)
+        self.assertIn("ProcessThreadUntilIdle", self.server)
+        self.assertNotIn("still active after 3s drain timeout", self.server)
+
+    def test_background_worker_owns_thread_safe_server_lifetime(self):
+        self.assertIn(
+            "TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Self = AsShared();",
+            self.server,
+        )
+        self.assertIn("FFunctionGraphTask::CreateAndDispatchWhenReady", self.server)
+        self.assertNotIn("[this, ClientSocket, EndpointStr]", self.server)
+
+    def test_exec_ticker_skips_backlog_before_running_one_body(self):
+        self.assertIn("while (ExecQueue.Dequeue(Pending))", self.server)
+        self.assertIn("if (bExecuted)", self.server)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Prevent queued GameThread work from executing after the server has already reported a timeout.

- add one shared `queued / running / cancelled / completed` lifecycle for Python exec and modal work
- allow cancellation to win only while work is still queued
- report `already started; outcome unknown` when the GameThread has already claimed the work
- serialize request admission against shutdown
- track and drain worker/GameThread closures before module unload
- discard cancelled exec tombstones in the same ticker pass before running one live body

## Behavior

Previously, an exec or `modal_action` request could time out on its socket worker while its queued GameThread closure remained alive. That closure could later execute Python, click a Slate control, or mutate text after the caller had already received a failure.

With this change:

- `queued -> cancelled` is terminal, publishes one result, and guarantees the body will never run
- `queued -> running -> completed` remains the normal execution path
- cancellation cannot relabel running work as cancelled
- shutdown closes admission, cancels queued exec work, closes client sockets, waits for tracked worker graph events, and drains remaining GameThread closures before returning
- existing response fields (`success`, `output`, `error`, `ready`) remain unchanged

Running Python/Slate work is not forcibly preempted; a timeout after `running` deliberately reports that its outcome is unknown.

## Validation

```text
py -3 -m unittest tools.test_bridge_discovery tools.test_bridge_modal_client tools.test_cancellable_work_contract -v
15 passed

py -3 tools/build_matrix.py --only 5.6 --verbose
UE 5.6 BuildPlugin: 81/81 actions, exit 0

py -3 tools/build_matrix.py --only 5.7 --verbose
UE 5.7 BuildPlugin: 81/81 actions, exit 0

UnrealEditor-Cmd.exe ... -ExecCmds="Automation RunTests UnrealBridge.Server.CancellableWork"
UE 5.7 Automation: 5 passed, 0 failed, 0 warnings
```

The Automation coverage includes queued cancellation, running cancellation failure, shutdown admission, production exec-queue tombstone draining, and shutdown waiting for a tracked socket worker closure.

UE 5.3-5.5 and 5.8 were not re-run locally for this PR. The changed C++ paths compile cleanly in both installed versions, UE 5.6 and UE 5.7.
