### PR TITLE
fix: route local gameplay helpers to the local PIE client

### DIFF
--- a/.claude/skills/unreal-bridge/references/bridge-gameplay-api.md
+++ b/.claude/skills/unreal-bridge/references/bridge-gameplay-api.md
@@ -861,8 +861,10 @@ Pass `(1, 0, 0)` for a bool "pressed"; for Axis2D WASD pass `(x, y, 0)`.
 ### set_sticky_input(input_action_path, axis_value) -> bool  /  clear_sticky_input(input_action_path="") -> bool
 
 Register a sticky injection: a server-side FTSTicker re-injects the
-registered IA/value **every GameThread frame** until cleared. Set once
-from Python, input persists at engine frame rate.
+registered IA/value **every GameThread frame** until explicitly cleared,
+overwritten, or automatically removed after the captured action/world/player
+identity becomes invalid. Set once from Python, input persists at engine frame
+rate while that identity remains valid.
 
 - `set_sticky_input(path, value)` — register or overwrite one entry.
 - `clear_sticky_input(path)` — remove one entry by path.
@@ -873,8 +875,11 @@ all held). Passing a zero vector does NOT clear — it injects zero
 every frame (useful to keep the binding alive while temporarily
 suspending input without losing the subscription).
 
-Sticky entries are auto-dropped when PIE ends, so each fresh PIE
-session starts with no sticky input. The server-side ticker stops
+Sticky entries are pinned to the originating PIE world, its world-time
+clock, FirstPlayerController, and LocalPlayer. They are auto-dropped
+without injection if PIE ends or either local-player identity object is
+replaced in the same world, so stale input cannot transfer during
+reconnect or controller replacement. The server-side ticker stops
 running when the registry is empty.
 
 **Example — hold forward for 2s:**

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeWorldSelectionTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeWorldSelectionTests.cpp
@@ -1,0 +1,229 @@
+#include "Misc/AutomationTest.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "UnrealBridgeWorldSelection.h"
+
+#include "Engine/Engine.h"
+#include "Engine/LocalPlayer.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "Runtime/Launch/Resources/Version.h"
+#include "UObject/Package.h"
+
+namespace UnrealBridgeWorldSelectionTests
+{
+	/**
+	 * 为选择器测试创建真实 UWorld、PlayerController 与 LocalPlayer，不把生产判定降级成布尔测试替身。
+	 * Creates real UWorld, PlayerController, and LocalPlayer objects so selector tests do not replace production predicates with booleans.
+	 */
+	class FScopedPIEWorld
+	{
+	public:
+		explicit FScopedPIEWorld(bool bHasBegunPlay, bool bAddPlayerController = false, bool bAttachLocalPlayer = false)
+		{
+			static int32 NextWorldIndex = 0;
+			const FName WorldName(*FString::Printf(TEXT("UnrealBridgeWorldSelection_%d"), NextWorldIndex++));
+			World = UWorld::CreateWorld(
+				EWorldType::PIE,
+				/*bInformEngineOfWorld=*/ false,
+				WorldName,
+				GetTransientPackage(),
+				/*bAddToRoot=*/ false);
+			if (!World)
+			{
+				return;
+			}
+
+			if (bAddPlayerController)
+			{
+				PlayerController = World->SpawnActor<APlayerController>();
+				if (PlayerController)
+				{
+					// 未初始化的瞬态世界不会替测试 Actor 建立 controller list；显式注册以复现生产 GetFirstPlayerController 路径。
+					// An uninitialized transient world does not build the controller list for test actors, so register explicitly to exercise the production GetFirstPlayerController path.
+					World->AddController(PlayerController);
+				}
+				if (PlayerController && bAttachLocalPlayer && GEngine)
+				{
+					// ULocalPlayer 声明 Within=Engine；使用实际引擎作为 Outer，保持与生产构造约束一致。
+					// ULocalPlayer declares Within=Engine, so use the live engine as its Outer to match production construction constraints.
+					LocalPlayer = NewObject<ULocalPlayer>(GEngine, NAME_None, RF_Transient);
+					PlayerController->SetPlayer(LocalPlayer);
+				}
+			}
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 4
+			World->bBegunPlay = bHasBegunPlay;
+#else
+			World->SetBegunPlay(bHasBegunPlay);
+#endif
+		}
+
+		~FScopedPIEWorld()
+		{
+			if (LocalPlayer && PlayerController && PlayerController->Player == LocalPlayer)
+			{
+				// SetPlayer 不接受空指针；先清除控制器侧测试引用，再销毁世界并回收 Engine-owned LocalPlayer。
+				// SetPlayer rejects null, so clear the controller-side test reference before destroying the world and collecting the engine-owned LocalPlayer.
+				PlayerController->Player = nullptr;
+			}
+			if (World)
+			{
+				if (PlayerController)
+				{
+					World->RemoveController(PlayerController);
+				}
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 4
+				World->bBegunPlay = false;
+#else
+				World->SetBegunPlay(false);
+#endif
+				World->DestroyWorld(/*bInformEngineOfWorld=*/ false);
+				World->MarkAsGarbage();
+			}
+			if (LocalPlayer)
+			{
+				LocalPlayer->MarkAsGarbage();
+			}
+		}
+
+		UWorld* GetWorld() const { return World; }
+		APlayerController* GetPlayerController() const { return PlayerController; }
+
+	private:
+		UWorld* World = nullptr;
+		APlayerController* PlayerController = nullptr;
+		ULocalPlayer* LocalPlayer = nullptr;
+	};
+
+	void AddPIEContext(TIndirectArray<FWorldContext>& Contexts, UWorld* World)
+	{
+		FWorldContext* Context = new FWorldContext();
+		Context->WorldType = EWorldType::PIE;
+		Context->SetCurrentWorld(World);
+		Contexts.Add(Context);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeGeneralWorldKeepsServerOrderTest,
+	"UnrealBridge.Gameplay.WorldSelection.ProductionWiring.GeneralKeepsFirstValid",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeGeneralWorldKeepsServerOrderTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	FScopedPIEWorld ServerWorld(/*bHasBegunPlay=*/ true);
+	FScopedPIEWorld LocalClientWorld(/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true, /*bAttachLocalPlayer=*/ true);
+	TestNotNull(TEXT("server world was created"), ServerWorld.GetWorld());
+	TestNotNull(TEXT("client first controller has an actual LocalPlayer"),
+		LocalClientWorld.GetPlayerController() ? LocalClientWorld.GetPlayerController()->GetLocalPlayer() : nullptr);
+
+	TIndirectArray<FWorldContext> Contexts;
+	AddPIEContext(Contexts, ServerWorld.GetWorld());
+	AddPIEContext(Contexts, LocalClientWorld.GetWorld());
+
+	TestEqual(TEXT("general and authority-sensitive calls preserve first-valid/server ordering"),
+		BridgeAgentImpl::SelectFirstValidPIEWorld(Contexts), ServerWorld.GetWorld());
+	TestEqual(TEXT("local player calls select the real local-client context"),
+		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts), LocalClientWorld.GetWorld());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeLocalWorldStartupFailsClosedTest,
+	"UnrealBridge.Gameplay.WorldSelection.ProductionWiring.ClientStartupFailsClosed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeLocalWorldStartupFailsClosedTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	FScopedPIEWorld ServerWorld(/*bHasBegunPlay=*/ true);
+	FScopedPIEWorld ClientWithoutLocalPlayer(/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true);
+	TestNotNull(TEXT("client has an actual first controller"), ClientWithoutLocalPlayer.GetPlayerController());
+	TestNull(TEXT("client first controller is not locally owned during startup"),
+		ClientWithoutLocalPlayer.GetPlayerController()
+			? ClientWithoutLocalPlayer.GetPlayerController()->GetLocalPlayer()
+			: nullptr);
+
+	TIndirectArray<FWorldContext> Contexts;
+	AddPIEContext(Contexts, ServerWorld.GetWorld());
+	AddPIEContext(Contexts, ClientWithoutLocalPlayer.GetWorld());
+
+	TestEqual(TEXT("general calls remain on the server during client startup"),
+		BridgeAgentImpl::SelectFirstValidPIEWorld(Contexts), ServerWorld.GetWorld());
+	TestNull(TEXT("local-only calls do not fall back to the server while the client is unready"),
+		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeLocalWorldRequiresBegunPlayTest,
+	"UnrealBridge.Gameplay.WorldSelection.ProductionWiring.RequiresBegunPlay",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeLocalWorldRequiresBegunPlayTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	FScopedPIEWorld UnreadyLocalWorld(/*bHasBegunPlay=*/ false, /*bAddPlayerController=*/ true, /*bAttachLocalPlayer=*/ true);
+	TestNotNull(TEXT("unready world still has a real local controller fixture"),
+		UnreadyLocalWorld.GetPlayerController()
+			? UnreadyLocalWorld.GetPlayerController()->GetLocalPlayer()
+			: nullptr);
+
+	TIndirectArray<FWorldContext> Contexts;
+	AddPIEContext(Contexts, UnreadyLocalWorld.GetWorld());
+	TestNull(TEXT("general selector rejects a PIE world before BeginPlay"),
+		BridgeAgentImpl::SelectFirstValidPIEWorld(Contexts));
+	TestNull(TEXT("local selector rejects a local controller before BeginPlay"),
+		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeStandaloneLocalWorldTest,
+	"UnrealBridge.Gameplay.WorldSelection.ProductionWiring.StandaloneLocal",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeStandaloneLocalWorldTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	FScopedPIEWorld StandaloneWorld(/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true, /*bAttachLocalPlayer=*/ true);
+	TIndirectArray<FWorldContext> Contexts;
+	AddPIEContext(Contexts, StandaloneWorld.GetWorld());
+
+	TestEqual(TEXT("standalone with a real LocalPlayer is a valid local-player world"),
+		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts), StandaloneWorld.GetWorld());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeServerOnlyHasNoLocalWorldTest,
+	"UnrealBridge.Gameplay.WorldSelection.ProductionWiring.ServerOnlyHasNoLocalWorld",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeServerOnlyHasNoLocalWorldTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	FScopedPIEWorld ServerWorld(/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true);
+	TIndirectArray<FWorldContext> Contexts;
+	AddPIEContext(Contexts, ServerWorld.GetWorld());
+
+	TestEqual(TEXT("server-only general operations retain the server world"),
+		BridgeAgentImpl::SelectFirstValidPIEWorld(Contexts), ServerWorld.GetWorld());
+	TestNull(TEXT("server-only sessions intentionally expose no local-player world"),
+		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts));
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeWorldSelectionTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeWorldSelectionTests.cpp
@@ -61,17 +61,25 @@ namespace UnrealBridgeWorldSelectionTests
 
 		~FScopedPIEWorld()
 		{
-			if (LocalPlayer && PlayerController && PlayerController->Player == LocalPlayer)
+			if (PlayerController)
 			{
 				// SetPlayer 不接受空指针；先清除控制器侧测试引用，再销毁世界并回收 Engine-owned LocalPlayer。
 				// SetPlayer rejects null, so clear the controller-side test reference before destroying the world and collecting the engine-owned LocalPlayer.
 				PlayerController->Player = nullptr;
+			}
+			if (ReplacementPlayerController)
+			{
+				ReplacementPlayerController->Player = nullptr;
 			}
 			if (World)
 			{
 				if (PlayerController)
 				{
 					World->RemoveController(PlayerController);
+				}
+				if (ReplacementPlayerController)
+				{
+					World->RemoveController(ReplacementPlayerController);
 				}
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 4
 				World->bBegunPlay = false;
@@ -85,15 +93,51 @@ namespace UnrealBridgeWorldSelectionTests
 			{
 				LocalPlayer->MarkAsGarbage();
 			}
+			if (ReplacementLocalPlayer)
+			{
+				ReplacementLocalPlayer->MarkAsGarbage();
+			}
 		}
 
 		UWorld* GetWorld() const { return World; }
 		APlayerController* GetPlayerController() const { return PlayerController; }
+		ULocalPlayer* GetLocalPlayer() const { return LocalPlayer; }
+
+		ULocalPlayer* ReplaceLocalPlayer()
+		{
+			if (!PlayerController || !GEngine)
+			{
+				return nullptr;
+			}
+			ReplacementLocalPlayer = NewObject<ULocalPlayer>(GEngine, NAME_None, RF_Transient);
+			PlayerController->SetPlayer(ReplacementLocalPlayer);
+			return ReplacementLocalPlayer;
+		}
+
+		APlayerController* ReplacePlayerController()
+		{
+			if (!World || !GEngine)
+			{
+				return nullptr;
+			}
+			World->RemoveController(PlayerController);
+			ReplacementPlayerController = World->SpawnActor<APlayerController>();
+			if (!ReplacementPlayerController)
+			{
+				return nullptr;
+			}
+			World->AddController(ReplacementPlayerController);
+			ReplacementLocalPlayer = NewObject<ULocalPlayer>(GEngine, NAME_None, RF_Transient);
+			ReplacementPlayerController->SetPlayer(ReplacementLocalPlayer);
+			return ReplacementPlayerController;
+		}
 
 	private:
 		UWorld* World = nullptr;
 		APlayerController* PlayerController = nullptr;
 		ULocalPlayer* LocalPlayer = nullptr;
+		APlayerController* ReplacementPlayerController = nullptr;
+		ULocalPlayer* ReplacementLocalPlayer = nullptr;
 	};
 
 	void AddPIEContext(TIndirectArray<FWorldContext>& Contexts, UWorld* World)
@@ -223,6 +267,43 @@ bool FUnrealBridgeServerOnlyHasNoLocalWorldTest::RunTest(const FString& Paramete
 		BridgeAgentImpl::SelectFirstValidPIEWorld(Contexts), ServerWorld.GetWorld());
 	TestNull(TEXT("server-only sessions intentionally expose no local-player world"),
 		BridgeAgentImpl::SelectFirstLocalPlayerPIEWorld(Contexts));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeStickyInputReplacementFailsClosedTest,
+	"UnrealBridge.Gameplay.StickyInput.ProductionWiring.ReplacementFailsClosed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeStickyInputReplacementFailsClosedTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeWorldSelectionTests;
+	(void)Parameters;
+
+	// 分别替换同一 PIE 世界中的 LocalPlayer 与 FirstPlayerController，确定旧粘滞身份不会被新对象继承。
+	// Replace the LocalPlayer and FirstPlayerController in separate same-world fixtures so a stale sticky identity cannot transfer to either new object.
+	FScopedPIEWorld LocalPlayerReplacementWorld(
+		/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true, /*bAttachLocalPlayer=*/ true);
+	UWorld* FirstWorld = LocalPlayerReplacementWorld.GetWorld();
+	APlayerController* FirstController = LocalPlayerReplacementWorld.GetPlayerController();
+	ULocalPlayer* FirstLocalPlayer = LocalPlayerReplacementWorld.GetLocalPlayer();
+	TestTrue(TEXT("captured local-player identity starts valid"),
+		BridgeAgentImpl::IsSameLocalPlayerPIEIdentity(FirstWorld, FirstController, FirstLocalPlayer));
+	TestNotNull(TEXT("replacement LocalPlayer was created"), LocalPlayerReplacementWorld.ReplaceLocalPlayer());
+	TestFalse(TEXT("replacing LocalPlayer in the same world invalidates the captured sticky identity"),
+		BridgeAgentImpl::IsSameLocalPlayerPIEIdentity(FirstWorld, FirstController, FirstLocalPlayer));
+
+	FScopedPIEWorld ControllerReplacementWorld(
+		/*bHasBegunPlay=*/ true, /*bAddPlayerController=*/ true, /*bAttachLocalPlayer=*/ true);
+	UWorld* SecondWorld = ControllerReplacementWorld.GetWorld();
+	APlayerController* SecondController = ControllerReplacementWorld.GetPlayerController();
+	ULocalPlayer* SecondLocalPlayer = ControllerReplacementWorld.GetLocalPlayer();
+	TestTrue(TEXT("second captured local-player identity starts valid"),
+		BridgeAgentImpl::IsSameLocalPlayerPIEIdentity(SecondWorld, SecondController, SecondLocalPlayer));
+	TestNotNull(TEXT("replacement FirstPlayerController was created"),
+		ControllerReplacementWorld.ReplacePlayerController());
+	TestFalse(TEXT("replacing FirstPlayerController in the same world invalidates the captured sticky identity"),
+		BridgeAgentImpl::IsSameLocalPlayerPIEIdentity(SecondWorld, SecondController, SecondLocalPlayer));
 	return true;
 }
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayLibrary.cpp
@@ -1,5 +1,6 @@
 #include "UnrealBridgeGameplayLibrary.h"
 
+#include "UnrealBridgeWorldSelection.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "ScopedTransaction.h"
@@ -71,6 +72,9 @@ namespace BridgeAgentImpl
 	{
 		TWeakObjectPtr<UInputAction> Action;
 		FVector Value = FVector::ZeroVector;
+		// 粘滞输入固定到创建它的本地玩家世界，禁止在多 PIE 启动或重连时跨世界切换时钟与注入目标。
+		// Sticky input is pinned to its originating local-player world so PIE startup/reconnect cannot switch its clock or injection target.
+		TWeakObjectPtr<UWorld> World;
 		// Auto-clear deadline in world-time seconds. <= 0 means "no deadline,
 		// caller will call ClearStickyInput". Set by TriggerInputAction() so
 		// a timed hold releases on its own.
@@ -121,21 +125,16 @@ namespace BridgeAgentImpl
 		}
 	}
 
-	/** Return the active PIE world, or nullptr if not playing. */
+	/** 返回首个有效 PIE 世界，保留通用及权威操作原有的上下文顺序语义。 */
 	UWorld* GetPIEWorld()
 	{
-		if (!GEditor)
-		{
-			return nullptr;
-		}
-		for (const FWorldContext& Ctx : GEditor->GetWorldContexts())
-		{
-			if (Ctx.WorldType == EWorldType::PIE && Ctx.World() && Ctx.World()->HasBegunPlay())
-			{
-				return Ctx.World();
-			}
-		}
-		return nullptr;
+		return GEditor ? SelectFirstValidPIEWorld(GEditor->GetWorldContexts()) : nullptr;
+	}
+
+	/** 返回首个已就绪的本地玩家 PIE 世界；客户端启动未就绪及纯服务端场景均显式返回空。 */
+	UWorld* GetLocalPlayerPIEWorld()
+	{
+		return GEditor ? SelectFirstLocalPlayerPIEWorld(GEditor->GetWorldContexts()) : nullptr;
 	}
 
 	APawn* GetPlayerPawn(UWorld* World)
@@ -192,10 +191,10 @@ bool UUnrealBridgeGameplayLibrary::GetAgentObservation(
 {
 	OutObservation = FAgentObservation();
 
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
-		UE_LOG(LogUnrealBridgeAgent, Verbose, TEXT("GetAgentObservation: PIE not running"));
+		UE_LOG(LogUnrealBridgeAgent, Verbose, TEXT("GetAgentObservation: no ready local-player PIE world"));
 		return false;
 	}
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
@@ -351,7 +350,7 @@ bool UUnrealBridgeGameplayLibrary::FindNavPath(
 
 bool UUnrealBridgeGameplayLibrary::ApplyMovementInput(const FVector& WorldDirection, float ScaleValue, bool bForce)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn)
 	{
@@ -363,7 +362,7 @@ bool UUnrealBridgeGameplayLibrary::ApplyMovementInput(const FVector& WorldDirect
 
 bool UUnrealBridgeGameplayLibrary::ApplyLookInput(float YawDelta, float PitchDelta)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -386,7 +385,7 @@ bool UUnrealBridgeGameplayLibrary::ApplyLookInput(float YawDelta, float PitchDel
 
 bool UUnrealBridgeGameplayLibrary::SetControlRotation(const FRotator& NewRotation)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -402,7 +401,7 @@ bool UUnrealBridgeGameplayLibrary::SetControlRotation(const FRotator& NewRotatio
 
 bool UUnrealBridgeGameplayLibrary::Jump()
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	ACharacter* Char = Cast<ACharacter>(Pawn);
 	if (!Char)
@@ -415,7 +414,7 @@ bool UUnrealBridgeGameplayLibrary::Jump()
 
 bool UUnrealBridgeGameplayLibrary::StopJumping()
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	ACharacter* Char = Cast<ACharacter>(Pawn);
 	if (!Char)
@@ -428,10 +427,10 @@ bool UUnrealBridgeGameplayLibrary::StopJumping()
 
 bool UUnrealBridgeGameplayLibrary::InjectEnhancedInputAxis(const FString& InputActionPath, const FVector& AxisValue)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
-		UE_LOG(LogUnrealBridgeAgent, Warning, TEXT("InjectEnhancedInputAxis: no PIE world"));
+		UE_LOG(LogUnrealBridgeAgent, Warning, TEXT("InjectEnhancedInputAxis: no ready local-player PIE world"));
 		return false;
 	}
 	APlayerController* PC = World->GetFirstPlayerController();
@@ -481,41 +480,39 @@ namespace BridgeAgentImpl
 			return true; // nothing to do — but keep ticker alive, caller may add more
 		}
 
-		UWorld* World = GetPIEWorld();
-		if (!World)
-		{
-			// PIE not running: drop all sticky entries, leaving a fresh
-			// slate for the next PIE session.
-			GStickyInputs.Reset();
-			return true;
-		}
-		APlayerController* PC = World->GetFirstPlayerController();
-		if (!PC || !PC->GetLocalPlayer())
-		{
-			return true;
-		}
-		UEnhancedInputLocalPlayerSubsystem* Subsystem =
-			PC->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
-		if (!Subsystem)
-		{
-			return true;
-		}
-
-		const double WorldNow = World->GetTimeSeconds();
 		for (TMap<FString, FStickyEntry>::TIterator It(GStickyInputs); It; ++It)
 		{
 			FStickyEntry& E = It->Value;
+			UWorld* World = E.World.Get();
+			UInputAction* Action = E.Action.Get();
+			if (!World || !World->HasBegunPlay() || !Action)
+			{
+				It.RemoveCurrent();
+				continue;
+			}
+
+			APlayerController* PlayerController = World->GetFirstPlayerController();
+			if (!PlayerController || !PlayerController->GetLocalPlayer())
+			{
+				// 原本地玩家失效后丢弃条目；不得把旧输入迟到注入新客户端或服务端世界。
+				// Drop entries whose original local player disappeared; never inject stale input into a new client or server world.
+				It.RemoveCurrent();
+				continue;
+			}
+
+			UEnhancedInputLocalPlayerSubsystem* Subsystem =
+				PlayerController->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
+			if (!Subsystem)
+			{
+				continue;
+			}
+
+			const double WorldNow = World->GetTimeSeconds();
 			if (E.AutoClearWorldTime > 0.0 && WorldNow >= E.AutoClearWorldTime)
 			{
 				UE_LOG(LogUnrealBridgeAgent, Verbose,
 					TEXT("StickyTick: auto-clear '%s' at world-time %.3f"),
 					*It->Key, WorldNow);
-				It.RemoveCurrent();
-				continue;
-			}
-			UInputAction* Action = E.Action.Get();
-			if (!Action)
-			{
 				It.RemoveCurrent();
 				continue;
 			}
@@ -537,9 +534,17 @@ bool UUnrealBridgeGameplayLibrary::SetStickyInput(const FString& InputActionPath
 			TEXT("SetStickyInput: failed to load IA '%s'"), *InputActionPath);
 		return false;
 	}
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
+	if (!World)
+	{
+		UE_LOG(LogUnrealBridgeAgent, Warning,
+			TEXT("SetStickyInput: no ready local-player PIE world for '%s'"), *InputActionPath);
+		return false;
+	}
 	BridgeAgentImpl::FStickyEntry Entry;
 	Entry.Action = Action;
 	Entry.Value = AxisValue;
+	Entry.World = World;
 	BridgeAgentImpl::GStickyInputs.Add(InputActionPath, Entry);
 	BridgeAgentImpl::EnsureStickyTickerRunning();
 	UE_LOG(LogUnrealBridgeAgent, Log, TEXT("SetStickyInput: %s = (%.2f, %.2f, %.2f)"),
@@ -676,11 +681,11 @@ bool UUnrealBridgeGameplayLibrary::TriggerInputAction(const FString& InputAction
 	}
 
 	// Sticky-hold path: need a PIE world to anchor the world-time deadline.
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		UE_LOG(LogUnrealBridgeAgent, Warning,
-			TEXT("TriggerInputAction: no PIE world; cannot schedule auto-clear for '%s'"),
+			TEXT("TriggerInputAction: no ready local-player PIE world; cannot schedule auto-clear for '%s'"),
 			*InputActionPath);
 		return false;
 	}
@@ -688,6 +693,7 @@ bool UUnrealBridgeGameplayLibrary::TriggerInputAction(const FString& InputAction
 	BridgeAgentImpl::FStickyEntry Entry;
 	Entry.Action = Action;
 	Entry.Value = FVector(1.0, 0.0, 0.0);
+	Entry.World = World;
 	Entry.AutoClearWorldTime = World->GetTimeSeconds() + EffectiveHold;
 	BridgeAgentImpl::GStickyInputs.Add(InputActionPath, Entry);
 	BridgeAgentImpl::EnsureStickyTickerRunning();
@@ -702,7 +708,7 @@ bool UUnrealBridgeGameplayLibrary::TriggerInputAction(const FString& InputAction
 bool UUnrealBridgeGameplayLibrary::GetControlRotation(FRotator& OutRotation)
 {
 	OutRotation = FRotator::ZeroRotator;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -818,7 +824,7 @@ namespace BridgeAgentImpl
 
 FString UUnrealBridgeGameplayLibrary::GetCameraHitActor(float MaxDistance)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	FVector CamLoc; FRotator CamRot;
 	if (!BridgeAgentImpl::GetCameraView(World, CamLoc, CamRot))
 	{
@@ -841,7 +847,7 @@ FString UUnrealBridgeGameplayLibrary::GetCameraHitActor(float MaxDistance)
 bool UUnrealBridgeGameplayLibrary::GetCameraHitLocation(float MaxDistance, FVector& OutHitLocation)
 {
 	OutHitLocation = FVector::ZeroVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	FVector CamLoc; FRotator CamRot;
 	if (!BridgeAgentImpl::GetCameraView(World, CamLoc, CamRot))
 	{
@@ -863,7 +869,7 @@ bool UUnrealBridgeGameplayLibrary::GetCameraHitLocation(float MaxDistance, FVect
 
 bool UUnrealBridgeGameplayLibrary::IsActorVisibleFromCamera(const FString& ActorName, float MaxDistance)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	FVector CamLoc; FRotator CamRot;
 	if (!BridgeAgentImpl::GetCameraView(World, CamLoc, CamRot))
 	{
@@ -916,7 +922,7 @@ bool UUnrealBridgeGameplayLibrary::IsActorVisibleFromCamera(const FString& Actor
 
 float UUnrealBridgeGameplayLibrary::GetPawnGroundHeight(float MaxDistance)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn)
 	{
@@ -1032,7 +1038,7 @@ bool UUnrealBridgeGameplayLibrary::GetRandomReachablePointInRadius(const FVector
 bool UUnrealBridgeGameplayLibrary::GetPIEViewportSize(FVector2D& OutSize)
 {
 	OutSize = FVector2D::ZeroVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -1057,7 +1063,7 @@ bool UUnrealBridgeGameplayLibrary::DeprojectScreenToWorld(float NormalizedX, flo
 {
 	OutOrigin = FVector::ZeroVector;
 	OutDirection = FVector::ForwardVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -1081,7 +1087,7 @@ bool UUnrealBridgeGameplayLibrary::DeprojectScreenToWorld(float NormalizedX, flo
 bool UUnrealBridgeGameplayLibrary::ProjectWorldToScreen(const FVector& WorldLocation, FVector2D& OutNormalized)
 {
 	OutNormalized = FVector2D::ZeroVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -1117,7 +1123,7 @@ namespace BridgeAgentImpl
 {
 	static APlayerCameraManager* GetPIECameraManager()
 	{
-		UWorld* World = GetPIEWorld();
+		UWorld* World = GetLocalPlayerPIEWorld();
 		if (!World) return nullptr;
 		APlayerController* PC = World->GetFirstPlayerController();
 		return PC ? PC->PlayerCameraManager : nullptr;
@@ -1160,9 +1166,12 @@ bool UUnrealBridgeGameplayLibrary::UnlockCameraFOV()
 
 namespace BridgeAgentImpl
 {
-	static UCharacterMovementComponent* GetPIECharMove()
+	/**
+	 * 从显式选择的世界读取玩家角色移动组件，不在辅助函数内隐藏 world policy。
+	 * Reads character movement from an explicitly selected world so the helper cannot hide world policy.
+	 */
+	static UCharacterMovementComponent* GetCharacterMovement(UWorld* World)
 	{
-		UWorld* World = GetPIEWorld();
 		APawn* Pawn = GetPlayerPawn(World);
 		if (ACharacter* Char = Cast<ACharacter>(Pawn))
 		{
@@ -1174,7 +1183,8 @@ namespace BridgeAgentImpl
 
 float UUnrealBridgeGameplayLibrary::GetPawnMaxWalkSpeed()
 {
-	UCharacterMovementComponent* Move = BridgeAgentImpl::GetPIECharMove();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
+	UCharacterMovementComponent* Move = BridgeAgentImpl::GetCharacterMovement(World);
 	return Move ? Move->MaxWalkSpeed : -1.0f;
 }
 
@@ -1184,7 +1194,8 @@ bool UUnrealBridgeGameplayLibrary::SetPawnMaxWalkSpeed(float Speed)
 	{
 		return false;
 	}
-	UCharacterMovementComponent* Move = BridgeAgentImpl::GetPIECharMove();
+	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UCharacterMovementComponent* Move = BridgeAgentImpl::GetCharacterMovement(World);
 	if (!Move)
 	{
 		return false;
@@ -1199,7 +1210,8 @@ bool UUnrealBridgeGameplayLibrary::SetPawnGravityScale(float Scale)
 	{
 		return false;
 	}
-	UCharacterMovementComponent* Move = BridgeAgentImpl::GetPIECharMove();
+	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UCharacterMovementComponent* Move = BridgeAgentImpl::GetCharacterMovement(World);
 	if (!Move)
 	{
 		return false;
@@ -1210,7 +1222,7 @@ bool UUnrealBridgeGameplayLibrary::SetPawnGravityScale(float Scale)
 
 float UUnrealBridgeGameplayLibrary::GetPawnSpeed()
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn)
 	{
@@ -1235,7 +1247,7 @@ bool UUnrealBridgeGameplayLibrary::GetPawnCapabilities(
 	bCanCrouch = false;
 	bCanJump = false;
 
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	ACharacter* Char = Cast<ACharacter>(BridgeAgentImpl::GetPlayerPawn(World));
 	if (!Char)
 	{
@@ -1607,7 +1619,7 @@ namespace BridgeAgentImpl
 {
 	static UEnhancedInputLocalPlayerSubsystem* GetEILocalPlayerSub()
 	{
-		UWorld* World = GetPIEWorld();
+		UWorld* World = GetLocalPlayerPIEWorld();
 		if (!World) return nullptr;
 		APlayerController* PC = World->GetFirstPlayerController();
 		if (!PC || !PC->GetLocalPlayer()) return nullptr;
@@ -1718,7 +1730,7 @@ bool UUnrealBridgeGameplayLibrary::FlushPersistentDebugDraws()
 bool UUnrealBridgeGameplayLibrary::GetPawnForwardVector(FVector& OutForward)
 {
 	OutForward = FVector::ForwardVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn) return false;
 	OutForward = Pawn->GetActorForwardVector();
@@ -1728,7 +1740,7 @@ bool UUnrealBridgeGameplayLibrary::GetPawnForwardVector(FVector& OutForward)
 bool UUnrealBridgeGameplayLibrary::GetPawnRightVector(FVector& OutRight)
 {
 	OutRight = FVector::RightVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn) return false;
 	OutRight = Pawn->GetActorRightVector();
@@ -1738,7 +1750,7 @@ bool UUnrealBridgeGameplayLibrary::GetPawnRightVector(FVector& OutRight)
 bool UUnrealBridgeGameplayLibrary::GetPawnUpVector(FVector& OutUp)
 {
 	OutUp = FVector::UpVector;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn) return false;
 	OutUp = Pawn->GetActorUpVector();
@@ -1747,7 +1759,7 @@ bool UUnrealBridgeGameplayLibrary::GetPawnUpVector(FVector& OutUp)
 
 float UUnrealBridgeGameplayLibrary::GetDistanceToPawn(const FVector& Location)
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	if (!Pawn) return -1.0f;
 	return FVector::Dist(Pawn->GetActorLocation(), Location);
@@ -1942,14 +1954,14 @@ namespace BridgeAgentImpl
 
 FString UUnrealBridgeGameplayLibrary::GetPlayerPawnActorName()
 {
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	return Pawn ? Pawn->GetFName().ToString() : FString();
 }
 
 USkeletalMeshComponent* UUnrealBridgeGameplayLibrary::GetPlayerSkeletalMeshComponent(const FString& ComponentName)
 {
-	return BridgeAgentImpl::GetPlayerSkeletalMeshComponent(BridgeAgentImpl::GetPIEWorld(), ComponentName);
+	return BridgeAgentImpl::GetPlayerSkeletalMeshComponent(BridgeAgentImpl::GetLocalPlayerPIEWorld(), ComponentName);
 }
 
 UAnimInstance* UUnrealBridgeGameplayLibrary::GetPlayerAnimInstance(const FString& ComponentName)
@@ -2079,7 +2091,7 @@ bool UUnrealBridgeGameplayLibrary::GetCameraViewPoint(FVector& OutLocation, FRot
 {
 	OutLocation = FVector::ZeroVector;
 	OutRotation = FRotator::ZeroRotator;
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	if (!World)
 	{
 		return false;
@@ -2100,7 +2112,7 @@ FString UUnrealBridgeGameplayLibrary::GetActorAtScreenPosition(float NormalizedX
 	{
 		return FString();
 	}
-	UWorld* World = BridgeAgentImpl::GetPIEWorld();
+	UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 	APawn* Pawn = BridgeAgentImpl::GetPlayerPawn(World);
 	const FVector End = Origin + Direction * FMath::Max(MaxDistance, 0.0f);
 
@@ -3157,11 +3169,7 @@ namespace BridgeInputRuntimeImpl
 {
 	static UEnhancedInputLocalPlayerSubsystem* GetActiveSubsystem()
 	{
-		UWorld* World = nullptr;
-		for (const FWorldContext& Ctx : GEngine->GetWorldContexts())
-		{
-			if (Ctx.WorldType == EWorldType::PIE) { World = Ctx.World(); break; }
-		}
+		UWorld* World = BridgeAgentImpl::GetLocalPlayerPIEWorld();
 		if (!World) return nullptr;
 		APlayerController* PC = World->GetFirstPlayerController();
 		if (!PC) return nullptr;

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeGameplayLibrary.cpp
@@ -8,6 +8,7 @@
 
 #include "Editor.h"
 #include "Engine/World.h"
+#include "Engine/LocalPlayer.h"
 #include "EngineUtils.h"
 #include "GameFramework/Pawn.h"
 #include "GameFramework/PlayerController.h"
@@ -72,9 +73,11 @@ namespace BridgeAgentImpl
 	{
 		TWeakObjectPtr<UInputAction> Action;
 		FVector Value = FVector::ZeroVector;
-		// 粘滞输入固定到创建它的本地玩家世界，禁止在多 PIE 启动或重连时跨世界切换时钟与注入目标。
-		// Sticky input is pinned to its originating local-player world so PIE startup/reconnect cannot switch its clock or injection target.
+		// 粘滞输入固定到创建时的世界、首个控制器和本地玩家；任一身份变化都必须丢弃，禁止旧输入重定向。
+		// Sticky input is pinned to its originating world, first controller, and local player; any identity change drops it instead of redirecting stale input.
 		TWeakObjectPtr<UWorld> World;
+		TWeakObjectPtr<APlayerController> PlayerController;
+		TWeakObjectPtr<ULocalPlayer> LocalPlayer;
 		// Auto-clear deadline in world-time seconds. <= 0 means "no deadline,
 		// caller will call ClearStickyInput". Set by TriggerInputAction() so
 		// a timed hold releases on its own.
@@ -491,17 +494,18 @@ namespace BridgeAgentImpl
 				continue;
 			}
 
-			APlayerController* PlayerController = World->GetFirstPlayerController();
-			if (!PlayerController || !PlayerController->GetLocalPlayer())
+			APlayerController* PlayerController = E.PlayerController.Get();
+			ULocalPlayer* LocalPlayer = E.LocalPlayer.Get();
+			if (!IsSameLocalPlayerPIEIdentity(World, PlayerController, LocalPlayer))
 			{
-				// 原本地玩家失效后丢弃条目；不得把旧输入迟到注入新客户端或服务端世界。
-				// Drop entries whose original local player disappeared; never inject stale input into a new client or server world.
+				// 原世界中的首控制器或本地玩家被替换后丢弃条目；不得把旧输入迟到注入替代身份。
+				// Drop the entry when the originating world's first controller or local player is replaced; never inject stale input into the replacement identity.
 				It.RemoveCurrent();
 				continue;
 			}
 
 			UEnhancedInputLocalPlayerSubsystem* Subsystem =
-				PlayerController->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
+				LocalPlayer->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
 			if (!Subsystem)
 			{
 				continue;
@@ -541,10 +545,20 @@ bool UUnrealBridgeGameplayLibrary::SetStickyInput(const FString& InputActionPath
 			TEXT("SetStickyInput: no ready local-player PIE world for '%s'"), *InputActionPath);
 		return false;
 	}
+	APlayerController* PlayerController = World->GetFirstPlayerController();
+	ULocalPlayer* LocalPlayer = PlayerController ? PlayerController->GetLocalPlayer() : nullptr;
+	if (!PlayerController || !LocalPlayer)
+	{
+		UE_LOG(LogUnrealBridgeAgent, Warning,
+			TEXT("SetStickyInput: local-player identity became unavailable for '%s'"), *InputActionPath);
+		return false;
+	}
 	BridgeAgentImpl::FStickyEntry Entry;
 	Entry.Action = Action;
 	Entry.Value = AxisValue;
 	Entry.World = World;
+	Entry.PlayerController = PlayerController;
+	Entry.LocalPlayer = LocalPlayer;
 	BridgeAgentImpl::GStickyInputs.Add(InputActionPath, Entry);
 	BridgeAgentImpl::EnsureStickyTickerRunning();
 	UE_LOG(LogUnrealBridgeAgent, Log, TEXT("SetStickyInput: %s = (%.2f, %.2f, %.2f)"),
@@ -690,10 +704,20 @@ bool UUnrealBridgeGameplayLibrary::TriggerInputAction(const FString& InputAction
 		return false;
 	}
 
+	APlayerController* PlayerController = World->GetFirstPlayerController();
+	ULocalPlayer* LocalPlayer = PlayerController ? PlayerController->GetLocalPlayer() : nullptr;
+	if (!PlayerController || !LocalPlayer)
+	{
+		UE_LOG(LogUnrealBridgeAgent, Warning,
+			TEXT("TriggerInputAction: local-player identity became unavailable for '%s'"), *InputActionPath);
+		return false;
+	}
 	BridgeAgentImpl::FStickyEntry Entry;
 	Entry.Action = Action;
 	Entry.Value = FVector(1.0, 0.0, 0.0);
 	Entry.World = World;
+	Entry.PlayerController = PlayerController;
+	Entry.LocalPlayer = LocalPlayer;
 	Entry.AutoClearWorldTime = World->GetTimeSeconds() + EffectiveHold;
 	BridgeAgentImpl::GStickyInputs.Add(InputActionPath, Entry);
 	BridgeAgentImpl::EnsureStickyTickerRunning();

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.cpp
@@ -52,4 +52,19 @@ namespace BridgeAgentImpl
 		}
 		return nullptr;
 	}
+
+	bool IsSameLocalPlayerPIEIdentity(
+		const UWorld* World,
+		const APlayerController* ExpectedPlayerController,
+		const ULocalPlayer* ExpectedLocalPlayer)
+	{
+		if (!World || !World->HasBegunPlay() || !ExpectedPlayerController || !ExpectedLocalPlayer)
+		{
+			return false;
+		}
+
+		const APlayerController* CurrentPlayerController = World->GetFirstPlayerController();
+		return CurrentPlayerController == ExpectedPlayerController
+			&& CurrentPlayerController->GetLocalPlayer() == ExpectedLocalPlayer;
+	}
 }

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.cpp
@@ -1,0 +1,55 @@
+#include "UnrealBridgeWorldSelection.h"
+
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+
+namespace BridgeAgentImpl
+{
+	namespace
+	{
+		/** 只接受已进入 BeginPlay 的 PIE 世界，避免 Editor/Preview 及启动中的半初始化世界。 */
+		UWorld* GetBegunPlayPIEWorld(const FWorldContext& WorldContext)
+		{
+			UWorld* World = WorldContext.World();
+			return WorldContext.WorldType == EWorldType::PIE
+				&& World
+				&& World->HasBegunPlay()
+				? World
+				: nullptr;
+		}
+	}
+
+	UWorld* SelectFirstValidPIEWorld(const TIndirectArray<FWorldContext>& WorldContexts)
+	{
+		for (const FWorldContext& WorldContext : WorldContexts)
+		{
+			if (UWorld* World = GetBegunPlayPIEWorld(WorldContext))
+			{
+				return World;
+			}
+		}
+		return nullptr;
+	}
+
+	UWorld* SelectFirstLocalPlayerPIEWorld(const TIndirectArray<FWorldContext>& WorldContexts)
+	{
+		for (const FWorldContext& WorldContext : WorldContexts)
+		{
+			UWorld* World = GetBegunPlayPIEWorld(WorldContext);
+			if (!World)
+			{
+				continue;
+			}
+
+			// 本库的玩家/相机 API 全部使用 FirstPlayerController，因此选择条件必须精确匹配消费者。
+			// Player/camera APIs in this library consume FirstPlayerController, so selection must match that exact predicate.
+			const APlayerController* PlayerController = World->GetFirstPlayerController();
+			if (PlayerController && PlayerController->GetLocalPlayer())
+			{
+				return World;
+			}
+		}
+		return nullptr;
+	}
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Containers/IndirectArray.h"
+#include "CoreTypes.h"
+
+class UWorld;
+struct FWorldContext;
+
+namespace BridgeAgentImpl
+{
+	/**
+	 * 按 Editor 提供的上下文顺序返回首个已开始运行的 PIE 世界，供通用及权威操作使用。
+	 * Returns the first begun-play PIE world in editor context order for general and authority-sensitive operations.
+	 */
+	UWorld* SelectFirstValidPIEWorld(const TIndirectArray<FWorldContext>& WorldContexts);
+
+	/**
+	 * 返回首个其首个 PlayerController 由 LocalPlayer 拥有的已运行 PIE 世界；本地客户端未就绪时显式返回空。
+	 * Returns the first begun-play PIE world whose first PlayerController is owned by a LocalPlayer; returns null while the local client is not ready.
+	 */
+	UWorld* SelectFirstLocalPlayerPIEWorld(const TIndirectArray<FWorldContext>& WorldContexts);
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeWorldSelection.h
@@ -3,6 +3,8 @@
 #include "Containers/IndirectArray.h"
 #include "CoreTypes.h"
 
+class APlayerController;
+class ULocalPlayer;
 class UWorld;
 struct FWorldContext;
 
@@ -19,4 +21,13 @@ namespace BridgeAgentImpl
 	 * Returns the first begun-play PIE world whose first PlayerController is owned by a LocalPlayer; returns null while the local client is not ready.
 	 */
 	UWorld* SelectFirstLocalPlayerPIEWorld(const TIndirectArray<FWorldContext>& WorldContexts);
+
+	/**
+	 * 仅当世界仍在运行，且其 FirstPlayerController 与 LocalPlayer 都和捕获身份完全相同时返回 true。
+	 * Returns true only while the world is still running and both its FirstPlayerController and LocalPlayer exactly match the captured identity.
+	 */
+	bool IsSameLocalPlayerPIEIdentity(
+		const UWorld* World,
+		const APlayerController* ExpectedPlayerController,
+		const ULocalPlayer* ExpectedLocalPlayer);
 }

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeGameplayLibrary.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeGameplayLibrary.h
@@ -31,15 +31,16 @@ struct FAgentVisibleActor
 	TArray<FName> Tags;
 };
 
-/** Packed agent-side observation of the PIE world. One UFUNCTION call
- *  assembles this so a Python agent loop doesn't need multiple bridge
- *  round-trips per tick. */
+/**
+ * 打包已就绪本地玩家 PIE 世界的 Agent 观测；一次 UFUNCTION 调用完成采集，减少 Python 循环往返。
+ * Packed observation of the ready local-player PIE world, assembled in one UFUNCTION to reduce Python round trips.
+ */
 USTRUCT(BlueprintType)
 struct FAgentObservation
 {
 	GENERATED_BODY()
 
-	/** False when PIE is not running or there is no player pawn yet. */
+	/** 没有已就绪的本地玩家 PIE 世界或尚未生成其玩家 Pawn 时为 false。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Agent")
 	bool bValid = false;
 
@@ -209,7 +210,7 @@ struct FBridgeInputActionState
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Agent")
 	float ElapsedProcessedTime = 0.f;
 
-	/** False iff there is no PIE / no active player input / no record for the IA. */
+	/** 没有已就绪的本地玩家 PIE 世界、没有活动 PlayerInput 或找不到该 IA 记录时为 false。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Agent")
 	bool bHasState = false;
 };
@@ -289,13 +290,18 @@ struct FBridgeInputBindingIssue
 };
 
 /**
- * Agent sensors + navigation for PIE automation.
+ * 为 PIE 自动化提供 Agent 传感、输入、相机及通用 Gameplay 操作。
  *
- * MVP scope:
- *   - GetAgentObservation: pawn state + nearby-actor list in one call.
- *   - FindNavPath: wrap UNavigationSystemV1::FindPathToLocationSynchronously.
+ * World policy 分为两个显式边界：
+ * - 本地输入、相机/视口、玩家传感及活动输入状态只使用“首个已 BeginPlay 且 FirstPlayerController 拥有 LocalPlayer”的世界；
+ *   客户端启动尚未就绪或纯服务端 PIE 时返回 false、空结果或约定哨兵，不回退到服务端世界。
+ * - Spawn/Destroy、Damage、Physics、Pause/TimeDilation、GameMode、Teleport/Respawn 及权威属性写入继续使用
+ *   Editor 上下文顺序中的首个有效 BeginPlay PIE 世界，以保留通用/权威语义。
+ * - Sticky input 固定到创建时的本地玩家世界及其 World Time；原世界或本地玩家失效时删除，不迁移到其他世界。
  *
- * Actuators (apply_movement_input, press_action, etc.) are a separate PR.
+ * Provides agent sensing, input, camera, and general gameplay operations for PIE automation.
+ * Local-player operations fail closed until a ready LocalPlayer world exists, while general/authority operations preserve first-valid context order.
+ * Sticky input remains pinned to its originating world and clock.
  */
 UCLASS()
 class UUnrealBridgeGameplayLibrary : public UBlueprintFunctionLibrary
@@ -304,17 +310,13 @@ class UUnrealBridgeGameplayLibrary : public UBlueprintFunctionLibrary
 
 public:
 	/**
-	 * Fill an FAgentObservation for the active PIE player pawn.
+	 * 采集已就绪本地玩家 PIE 世界中玩家 Pawn 的 FAgentObservation；客户端启动未就绪及纯服务端 PIE 显式失败。
 	 *
-	 * @param OutObservation     Populated struct. Check bValid before reading.
-	 * @param MaxActorDistance   Filter radius (cm). Actors farther than this
-	 *                           are dropped from VisibleActors.
-	 * @param bRequireLineOfSight  If true, do a camera-to-actor line trace;
-	 *                           drop actors that are occluded.
-	 * @param ClassFilter        Optional substring match on class name
-	 *                           (case-insensitive). Empty = all pawns+actors.
-	 * @return true when a PIE world + player pawn exist, false otherwise
-	 *         (OutObservation.bValid mirrors the return).
+	 * @param OutObservation 输出观测；读取其他字段前检查 bValid。
+	 * @param MaxActorDistance 过滤半径，单位 cm；更远 Actor 不进入 VisibleActors。
+	 * @param bRequireLineOfSight 为 true 时执行相机到 Actor 的射线检测并排除遮挡目标。
+	 * @param ClassFilter 可选的不区分大小写类名子串；空字符串表示不过滤。
+	 * @return 仅在已就绪本地玩家世界及其玩家 Pawn 均存在时返回 true；bValid 与返回值一致。
 	 *
 	 * Cost: O(N) scan of pawns in the PIE world + one line trace per candidate
 	 * if bRequireLineOfSight. Single GameThread call. Typical <1ms for small
@@ -356,8 +358,8 @@ public:
 
 	// ─── Actuators ────────────────────────────────────────────────────
 	//
-	// All actuators target the PIE world's first player pawn/controller.
-	// They return false when PIE is not running or no pawn exists.
+	// 下列输入执行器只作用于已就绪本地玩家世界的 FirstPlayerController/Pawn；客户端启动未就绪或纯服务端时返回 false。
+	// The input actuators below target only the ready local-player world's first controller/pawn and fail closed during startup or server-only PIE.
 	//
 	// Input is per-frame accumulative (UE's standard APawn pattern):
 	// AddMovementInput is consumed by the movement component once per
@@ -408,8 +410,9 @@ public:
 	static bool StopJumping();
 
 	/**
+	 * 向已就绪本地玩家的 EnhancedInput InputAction 注入单 tick 值；没有该本地玩家世界时返回 false，不回退服务端。
 	 * Inject a single-tick value into an EnhancedInput InputAction for
-	 * the PIE player. Good for discrete "press" actions (IA_Jump,
+	 * the ready local PIE player. Good for discrete "press" actions (IA_Jump,
 	 * IA_Interact) — one call fires the "Pressed"/"Triggered" phase
 	 * for that frame.
 	 *
@@ -429,7 +432,10 @@ public:
 	static bool InjectEnhancedInputAxis(const FString& InputActionPath, const FVector& AxisValue);
 
 	/**
-	 * Set a "sticky" EnhancedInput value: re-injected every GameThread
+	 * 设置粘滞 EnhancedInput 值并固定到当前已就绪本地玩家世界；每 tick 使用同一世界及 World Time 重注入。
+	 * 原世界或本地玩家失效时条目被删除，绝不迁移到其他客户端或服务端；没有已就绪本地玩家时返回 false。
+	 *
+	 * Set a "sticky" EnhancedInput value pinned to the current ready local-player world: re-injected every GameThread
 	 * tick until cleared or overwritten. The caller sets it once and
 	 * movement/look input persists at UE frame rate without Python
 	 * needing to keep up. Multiple IAs can be sticky at the same time
@@ -458,7 +464,8 @@ public:
 	static bool GetControlRotation(FRotator& OutRotation);
 
 	/**
-	 * Hard-reset the pawn's pose. Combines SetActorLocationAndRotation
+	 * 在通用/权威 world policy 的首个有效 PIE 世界中硬重置 Pawn，不使用本地玩家 fail-closed 选择。
+	 * Hard-reset the pawn's pose in the first-valid general/authority PIE world. Combines SetActorLocationAndRotation
 	 * with optional controller re-alignment and velocity clearing so a
 	 * Python agent can drop the pawn at a known state for scenario setup.
 	 *
@@ -651,9 +658,9 @@ public:
 
 	// ─── Character movement tuning ────────────────────────────────────
 	//
-	// All four target the PIE player pawn's UCharacterMovementComponent.
-	// They return a sentinel / false for non-Character pawns (raw APawn
-	// subclasses without CharMove won't respond).
+	// 读取 API 使用已就绪本地玩家 Pawn；MaxWalkSpeed/GravityScale 写入使用首个有效通用/权威 PIE 世界。
+	// Read APIs use the ready local-player pawn; MaxWalkSpeed/GravityScale mutations use the first-valid general/authority PIE world.
+	// 非 Character Pawn 返回哨兵或 false；raw APawn 没有 CharacterMovementComponent。
 
 	/**
 	 * `UCharacterMovementComponent::MaxWalkSpeed` in cm/s.
@@ -979,6 +986,9 @@ public:
 		TArray<float>& OutThresholdSeconds);
 
 	/**
+	 * 自适应触发 Bool IA；仅使用已就绪本地玩家世界。Sticky hold 的截止时间与重注入固定到创建时的同一世界。
+	 * 客户端启动未就绪或纯服务端 PIE 时返回 false，且不会稍后迁移/补发到其他世界。
+	 *
 	 * Adaptive "press a Bool IA" entry point. Inspects the IA's Triggers
 	 * and picks between single-tick inject vs. sticky-then-auto-release so
 	 * callers don't have to know which pattern fits a given action.
@@ -1188,11 +1198,11 @@ public:
 
 	// ─── E1 / E2 / E4 — PIE runtime state ───────────────────────────
 
-	/** Snapshot the LocalPlayer Subsystem's currently-active IMC stack. */
+	/** 读取已就绪本地玩家 Subsystem 的活动 IMC 栈；客户端未就绪或纯服务端 PIE 返回空数组。 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Agent")
 	static TArray<FBridgeMappingContextEntry> GetActiveMappingContextStack();
 
-	/** Read live runtime state for an IA (E2). */
+	/** 读取已就绪本地玩家的 IA 运行时状态；客户端未就绪或纯服务端 PIE 返回 bHasState=false。 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Agent")
 	static FBridgeInputActionState GetCurrentInputActionState(const FString& InputActionPath);
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeGameplayLibrary.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeGameplayLibrary.h
@@ -297,11 +297,11 @@ struct FBridgeInputBindingIssue
  *   客户端启动尚未就绪或纯服务端 PIE 时返回 false、空结果或约定哨兵，不回退到服务端世界。
  * - Spawn/Destroy、Damage、Physics、Pause/TimeDilation、GameMode、Teleport/Respawn 及权威属性写入继续使用
  *   Editor 上下文顺序中的首个有效 BeginPlay PIE 世界，以保留通用/权威语义。
- * - Sticky input 固定到创建时的本地玩家世界及其 World Time；原世界或本地玩家失效时删除，不迁移到其他世界。
+ * - Sticky input 固定到创建时的本地玩家世界、FirstPlayerController、LocalPlayer 及 World Time；任一身份变化时删除，不迁移到替代对象。
  *
  * Provides agent sensing, input, camera, and general gameplay operations for PIE automation.
  * Local-player operations fail closed until a ready LocalPlayer world exists, while general/authority operations preserve first-valid context order.
- * Sticky input remains pinned to its originating world and clock.
+ * Sticky input remains pinned to its originating world, first controller, local player, and world clock.
  */
 UCLASS()
 class UUnrealBridgeGameplayLibrary : public UBlueprintFunctionLibrary
@@ -436,9 +436,8 @@ public:
 	 * 原世界或本地玩家失效时条目被删除，绝不迁移到其他客户端或服务端；没有已就绪本地玩家时返回 false。
 	 *
 	 * Set a "sticky" EnhancedInput value pinned to the current ready local-player world: re-injected every GameThread
-	 * tick until cleared or overwritten. The caller sets it once and
-	 * movement/look input persists at UE frame rate without Python
-	 * needing to keep up. Multiple IAs can be sticky at the same time
+	 * tick until explicitly cleared, overwritten, or automatically removed when the captured action/world/player identity becomes invalid.
+	 * The caller sets it once and movement/look input persists at UE frame rate while that identity remains valid, without Python needing to keep up. Multiple IAs can be sticky at the same time
 	 * (e.g. hold forward + look yaw continuously).
 	 *
 	 * Calling SetStickyInput with the same InputActionPath overwrites

--- a/tools/test_gameplay_world_routing_contract.py
+++ b/tools/test_gameplay_world_routing_contract.py
@@ -1,0 +1,165 @@
+"""Source contract for typed Gameplay Library PIE-world routing."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = (
+    ROOT
+    / "Plugin"
+    / "UnrealBridge"
+    / "Source"
+    / "UnrealBridge"
+    / "Private"
+    / "UnrealBridgeGameplayLibrary.cpp"
+)
+SOURCE = SOURCE_PATH.read_text(encoding="utf-8")
+
+GENERAL_CALLERS = {
+    "FindNavPath",
+    "TeleportPawn",
+    "IsInPIE",
+    "GetNavWorld",
+    "SetPawnMaxWalkSpeed",
+    "SetPawnGravityScale",
+    "SimulateJumpArc",
+    "SpawnActorInPIE",
+    "DestroyActorInPIE",
+    "GetPIEActorLocation",
+    "GetGlobalTimeDilation",
+    "SetGlobalTimeDilation",
+    "GetActorTimeDilation",
+    "SetActorTimeDilation",
+    "PlaySound2D",
+    "PlaySoundAtLocation",
+    "ApplyDamageToActor",
+    "GetAllPawns",
+    "GetAIPawns",
+    "GetActorController",
+    "DrawDebugLine",
+    "DrawDebugSphereAt",
+    "DrawDebugBoxAt",
+    "DrawDebugArrow",
+    "DrawDebugString",
+    "FlushPersistentDebugDraws",
+    "GetPIEDeltaSeconds",
+    "GetPIENumPlayers",
+    "GetPIENumAIControllers",
+    "GetPIEPrimitive",
+    "PlayWorldCameraShake",
+    "FindPlayerStart",
+    "RespawnPlayerPawn",
+    "PauseGame",
+    "IsGamePaused",
+    "GetGameModeClassName",
+    "GetGameStateClassName",
+    "ApplyRadialDamage",
+    "FindPIEActorsByClass",
+}
+
+LOCAL_PLAYER_CALLERS = {
+    "GetAgentObservation",
+    "ApplyMovementInput",
+    "ApplyLookInput",
+    "SetControlRotation",
+    "Jump",
+    "StopJumping",
+    "InjectEnhancedInputAxis",
+    "SetStickyInput",
+    "TriggerInputAction",
+    "GetControlRotation",
+    "GetCameraHitActor",
+    "GetCameraHitLocation",
+    "IsActorVisibleFromCamera",
+    "GetPawnGroundHeight",
+    "GetPIEViewportSize",
+    "DeprojectScreenToWorld",
+    "ProjectWorldToScreen",
+    "GetPIECameraManager",
+    "GetPawnMaxWalkSpeed",
+    "GetPawnSpeed",
+    "GetPawnCapabilities",
+    "GetEILocalPlayerSub",
+    "GetActiveSubsystem",
+    "GetPawnForwardVector",
+    "GetPawnRightVector",
+    "GetPawnUpVector",
+    "GetDistanceToPawn",
+    "GetPlayerPawnActorName",
+    "GetPlayerSkeletalMeshComponent",
+    "GetCameraViewPoint",
+    "GetActorAtScreenPosition",
+}
+
+
+def _function_body(name: str) -> str:
+    public_pattern = re.compile(
+        rf"UUnrealBridgeGameplayLibrary::{re.escape(name)}\s*\([^;{{}}]*\)\s*\{{",
+        re.MULTILINE,
+    )
+    helper_pattern = re.compile(
+        rf"^[\t ]*(?:static\s+)?[^\n;{{}}]+\s+{re.escape(name)}\s*\([^;{{}}]*\)\s*\{{",
+        re.MULTILINE,
+    )
+    match = public_pattern.search(SOURCE) or helper_pattern.search(SOURCE)
+    if match is None:
+        raise AssertionError(f"production function not found: {name}")
+
+    opening_brace = SOURCE.find("{", match.start())
+    depth = 0
+    for index in range(opening_brace, len(SOURCE)):
+        if SOURCE[index] == "{":
+            depth += 1
+        elif SOURCE[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return SOURCE[opening_brace : index + 1]
+    raise AssertionError(f"unterminated production function: {name}")
+
+
+class GameplayWorldRoutingContractTests(unittest.TestCase):
+    def test_every_direct_world_source_caller_is_typed_and_classified(self) -> None:
+        for name in sorted(GENERAL_CALLERS):
+            body = _function_body(name)
+            self.assertIn("GetPIEWorld()", body, name)
+            self.assertNotIn("GetLocalPlayerPIEWorld()", body, name)
+
+        for name in sorted(LOCAL_PLAYER_CALLERS):
+            body = _function_body(name)
+            self.assertIn("GetLocalPlayerPIEWorld()", body, name)
+            self.assertNotIn("BridgeAgentImpl::GetPIEWorld()", body, name)
+
+        # The extra occurrence in each count is the source function definition.
+        self.assertEqual(SOURCE.count("GetPIEWorld()"), len(GENERAL_CALLERS) + 1)
+        self.assertEqual(
+            SOURCE.count("GetLocalPlayerPIEWorld()"),
+            len(LOCAL_PLAYER_CALLERS) + 1,
+        )
+        self.assertEqual(len(GENERAL_CALLERS), 39)
+        self.assertEqual(len(LOCAL_PLAYER_CALLERS), 31)
+        self.assertEqual(len(GENERAL_CALLERS | LOCAL_PLAYER_CALLERS), 70)
+        self.assertTrue(GENERAL_CALLERS.isdisjoint(LOCAL_PLAYER_CALLERS))
+
+    def test_no_independent_pie_context_scans_bypass_typed_sources(self) -> None:
+        general_source = _function_body("GetPIEWorld")
+        local_source = _function_body("GetLocalPlayerPIEWorld")
+        self.assertIn("GetWorldContexts()", general_source)
+        self.assertIn("GetWorldContexts()", local_source)
+        self.assertEqual(SOURCE.count("GetWorldContexts()"), 2)
+        self.assertNotIn("EWorldType::PIE", SOURCE)
+
+    def test_sticky_input_is_pinned_to_its_originating_world(self) -> None:
+        sticky_tick = _function_body("StickyTick")
+        self.assertIn("E.World.Get()", sticky_tick)
+        self.assertNotIn("GetPIEWorld()", sticky_tick)
+        self.assertNotIn("GetLocalPlayerPIEWorld()", sticky_tick)
+        self.assertIn("TWeakObjectPtr<UWorld> World;", SOURCE)
+        self.assertEqual(SOURCE.count("Entry.World = World;"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_gameplay_world_routing_contract.py
+++ b/tools/test_gameplay_world_routing_contract.py
@@ -152,13 +152,22 @@ class GameplayWorldRoutingContractTests(unittest.TestCase):
         self.assertEqual(SOURCE.count("GetWorldContexts()"), 2)
         self.assertNotIn("EWorldType::PIE", SOURCE)
 
-    def test_sticky_input_is_pinned_to_its_originating_world(self) -> None:
+    def test_sticky_input_is_pinned_to_its_originating_local_player_identity(self) -> None:
         sticky_tick = _function_body("StickyTick")
         self.assertIn("E.World.Get()", sticky_tick)
+        self.assertIn("E.PlayerController.Get()", sticky_tick)
+        self.assertIn("E.LocalPlayer.Get()", sticky_tick)
+        self.assertIn("IsSameLocalPlayerPIEIdentity(World, PlayerController, LocalPlayer)", sticky_tick)
+        self.assertIn("const double WorldNow = World->GetTimeSeconds()", sticky_tick)
+        self.assertNotIn("GetFirstPlayerController()", sticky_tick)
         self.assertNotIn("GetPIEWorld()", sticky_tick)
         self.assertNotIn("GetLocalPlayerPIEWorld()", sticky_tick)
         self.assertIn("TWeakObjectPtr<UWorld> World;", SOURCE)
+        self.assertIn("TWeakObjectPtr<APlayerController> PlayerController;", SOURCE)
+        self.assertIn("TWeakObjectPtr<ULocalPlayer> LocalPlayer;", SOURCE)
         self.assertEqual(SOURCE.count("Entry.World = World;"), 2)
+        self.assertEqual(SOURCE.count("Entry.PlayerController = PlayerController;"), 2)
+        self.assertEqual(SOURCE.count("Entry.LocalPlayer = LocalPlayer;"), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- split Gameplay Library world selection into explicit **general/authority** and **ready local-player** PIE sources
- route all 70 direct consumers through an executable 39-general / 31-local classification
- keep spawn/destroy, teleport/respawn, damage, physics, pause/time dilation, GameMode and other authority/general operations on upstream-compatible first-valid context ordering
- route local input, camera/viewport, local pawn sensors, mapping-stack and input-state queries to the first begun-play world whose first controller owns a `ULocalPlayer`
- pin sticky input to its originating weak world so reconnect/startup cannot change its clock or injection target

No reflected function signature changes.

## Failure behavior

When a client context exists but its `LocalPlayer` is not ready, local-only helpers fail closed rather than falling back to the server. General/authority helpers continue to use the first valid begun-play PIE world. Server-only PIE therefore intentionally has no local-player world.

## Regression coverage

- source contract inventories every direct caller, enforces disjoint 39/31 ownership, permits only the two typed `GetWorldContexts()` reads, rejects independent raw PIE scans, and checks sticky-world pinning
- asset-free C++ Automation creates real transient `UWorld`, `FWorldContext`, controller-list, `APlayerController`, and Engine-owned `ULocalPlayer` fixtures and executes the production harvesting predicates

## Validation

- Python routing/discovery/modal tests: 11/11 pass
- `py_compile`: pass
- UE 5.6 BuildPlugin: 82/82 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 BuildPlugin: 82/82 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 Automation `UnrealBridge.Gameplay.WorldSelection.ProductionWiring`: 5 succeeded, 0 failed, 0 warnings/not-run, Queue Empty

## Compatibility / remaining coverage

Built on UE 5.6 and 5.7. UE 5.3-5.5 and 5.8 were not locally available. A live one-process dedicated-server + local-client PIE session was not run; production context harvesting and the server-first/client-startup/standalone/server-only states are covered deterministically by Automation.
