### PR TITLE
feat: add external owner variable nodes

### DIFF
--- a/.claude/skills/unreal-bridge/references/bridge-blueprint-api.md
+++ b/.claude/skills/unreal-bridge/references/bridge-blueprint-api.md
@@ -684,6 +684,20 @@ get_guid = lib.add_variable_node('/Game/BP/BP_Hero', 'EventGraph', 'Health', Fal
 set_guid = lib.add_variable_node('/Game/BP/BP_Hero', 'EventGraph', 'Health', True,  400, 200)
 ```
 
+### add_external_variable_node(blueprint_path, graph_name, owner_class_path, variable_name, is_set, node_pos_x, node_pos_y) -> str
+
+Create a Variable Get (`is_set=False`) or Set (`is_set=True`) node whose target is an object of an explicit external class. `owner_class_path` is required and cannot be empty; use `add_variable_node` for self members. The property must exist and be readable or writable from the consumer Blueprint under Unreal Engine's canonical Blueprint access rules; this rejects Blueprint-private properties owned by an unrelated Blueprint, and a Set also rejects Blueprint-read-only properties. When the property is inherited, the node reference binds to the class that actually declares it rather than the requested derived class.
+
+The returned GUID follows the other graph-write APIs: it is a 32-character hex string on success and `""` on failure. Failures emit an `AddExternalVariableNode failed` warning with the requested Blueprint, graph, class, property, operation, and reason. Validation occurs before the single undo transaction, so a failed call does not add a graph node. The target input pin is named `self`; the value pin is named after the property (Set nodes may also expose the engine-provided `Output_Get` pin).
+
+```python
+get_range = lib.add_external_variable_node(
+    '/Game/BP/BP_Consumer', 'EventGraph',
+    '/Script/MyModule.InteractableComponent', 'InteractionRange', False, 0, 200)
+```
+
+This operation does not compile automatically. Connect the `self` and value pins as needed, then call `compile_blueprints` once after the batch of graph edits.
+
 ### connect_graph_pins(blueprint_path, graph_name, src_node_guid, src_pin_name, dst_node_guid, dst_pin_name) -> bool
 
 Connect pins through the K2 schema. Handles type coercion (e.g. int → string auto-inserts a conversion where supported). Returns `False` when nodes/pins are missing or types are incompatible.

--- a/.claude/skills/unreal-bridge/scripts/bridge_manifest.json
+++ b/.claude/skills/unreal-bridge/scripts/bridge_manifest.json
@@ -3264,6 +3264,54 @@
           ],
           "returns": "str"
         },
+        "add_external_variable_node": {
+          "doc": "X.add_external_variable_node(blueprint_path, graph_name, owner_class_path, variable_name, is_set, node_pos_x, node_pos_y) -> str",
+          "params": [
+            {
+              "default": null,
+              "has_default": false,
+              "name": "blueprint_path",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "graph_name",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "owner_class_path",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "variable_name",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "is_set",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "node_pos_x",
+              "type": ""
+            },
+            {
+              "default": null,
+              "has_default": false,
+              "name": "node_pos_y",
+              "type": ""
+            }
+          ],
+          "returns": "str"
+        },
         "add_for_loop_node": {
           "doc": "X.add_for_loop_node(blueprint_path, graph_name, with_break, x, y) -> str",
           "params": [

--- a/Plugin/UnrealBridge/Content/Python/unreal_bridge.py
+++ b/Plugin/UnrealBridge/Content/Python/unreal_bridge.py
@@ -701,6 +701,11 @@ class Blueprint:
         return unreal.UnrealBridgeBlueprintLibrary.add_event_node(blueprint_path, graph_name, parent_class_path, event_name, node_pos_x, node_pos_y)
 
     @staticmethod
+    def add_external_variable_node(*, blueprint_path, graph_name, owner_class_path, variable_name, is_set, node_pos_x, node_pos_y):
+        """X.add_external_variable_node(blueprint_path, graph_name, owner_class_path, variable_name, is_set, node_pos_x, node_pos_y) -> str"""
+        return unreal.UnrealBridgeBlueprintLibrary.add_external_variable_node(blueprint_path, graph_name, owner_class_path, variable_name, is_set, node_pos_x, node_pos_y)
+
+    @staticmethod
     def add_for_loop_node(*, blueprint_path, graph_name, with_break, x, y):
         """X.add_for_loop_node(blueprint_path, graph_name, with_break, x, y) -> str"""
         return unreal.UnrealBridgeBlueprintLibrary.add_for_loop_node(blueprint_path, graph_name, with_break, x, y)

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeAddExternalVariableNodeTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeAddExternalVariableNodeTests.cpp
@@ -1,0 +1,299 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Algo/Count.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/ScopeExit.h"
+#include "UnrealBridgeBlueprintLibrary.h"
+
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraph/EdGraphPin.h"
+#include "EdGraphSchema_K2.h"
+#include "Engine/Blueprint.h"
+#include "Engine/BlueprintGeneratedClass.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Character.h"
+#include "K2Node_Variable.h"
+#include "K2Node_VariableGet.h"
+#include "K2Node_VariableSet.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectHash.h"
+
+namespace UnrealBridgeAddExternalVariableNodeTests
+{
+	UK2Node_Variable* FindVariableNodeByGuid(UEdGraph* Graph, const FString& GuidString)
+	{
+		FGuid Guid;
+		if (!Graph || !FGuid::Parse(GuidString, Guid))
+		{
+			return nullptr;
+		}
+
+		for (UEdGraphNode* Node : Graph->Nodes)
+		{
+			if (Node && Node->NodeGuid == Guid)
+			{
+				return Cast<UK2Node_Variable>(Node);
+			}
+		}
+		return nullptr;
+	}
+
+	// 只统计图直接拥有且未标记为垃圾的变量节点，用于证明 preflight candidate 已在返回前清理。
+	// Count only live variable nodes directly owned by the graph to prove preflight candidates are cleaned before return.
+	int32 CountLiveGraphOwnedVariableNodes(UEdGraph* Graph)
+	{
+		TArray<UObject*> GraphChildren;
+		GetObjectsWithOuter(
+			Graph, GraphChildren, false, RF_NoFlags, EInternalObjectFlags::Garbage);
+		return Algo::CountIf(GraphChildren, [](const UObject* Object)
+		{
+			return Object && Object->IsA<UK2Node_Variable>();
+		});
+	}
+
+	// 测试对象全部放在 TransientPackage 中，并显式清除资产标志，避免保存资产或污染后续自动化用例。
+	// Keep every fixture in the TransientPackage and explicitly clear asset flags so no asset is saved or retained by later tests.
+	void CleanupTransientBlueprint(UBlueprint* Blueprint)
+	{
+		if (!Blueprint)
+		{
+			return;
+		}
+
+		if (Blueprint->GeneratedClass)
+		{
+			Blueprint->GeneratedClass->ClearFlags(RF_Public | RF_Standalone);
+			Blueprint->GeneratedClass->MarkAsGarbage();
+		}
+		if (Blueprint->SkeletonGeneratedClass && Blueprint->SkeletonGeneratedClass != Blueprint->GeneratedClass)
+		{
+			Blueprint->SkeletonGeneratedClass->ClearFlags(RF_Public | RF_Standalone);
+			Blueprint->SkeletonGeneratedClass->MarkAsGarbage();
+		}
+		Blueprint->ClearFlags(RF_Public | RF_Standalone);
+		Blueprint->MarkAsGarbage();
+	}
+}
+
+// 通过纯瞬态蓝图覆盖生产入口的成功与拒绝路径，不依赖内容资产或磁盘状态。
+// Exercise production success and rejection paths through a transient Blueprint without content assets or disk state.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeAddExternalVariableNodeTransientTest,
+	"UnrealBridge.Blueprint.AddExternalVariableNode.Transient",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeAddExternalVariableNodeTransientTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeAddExternalVariableNodeTests;
+	(void)Parameters;
+
+	const FName BlueprintName = MakeUniqueObjectName(
+		GetTransientPackage(), UBlueprint::StaticClass(), TEXT("UB_AddExternalVariableNode_Consumer"));
+	UBlueprint* Blueprint = FKismetEditorUtilities::CreateBlueprint(
+		UObject::StaticClass(), GetTransientPackage(), BlueprintName, BPTYPE_Normal,
+		UBlueprint::StaticClass(), UBlueprintGeneratedClass::StaticClass(), NAME_None);
+	if (!TestNotNull(TEXT("Create a transient consumer Blueprint"), Blueprint))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		CleanupTransientBlueprint(Blueprint);
+	};
+
+	const FName ProviderName = MakeUniqueObjectName(
+		GetTransientPackage(), UBlueprint::StaticClass(), TEXT("UB_AddExternalVariableNode_Provider"));
+	UBlueprint* ProviderBlueprint = FKismetEditorUtilities::CreateBlueprint(
+		UObject::StaticClass(), GetTransientPackage(), ProviderName, BPTYPE_Normal,
+		UBlueprint::StaticClass(), UBlueprintGeneratedClass::StaticClass(), NAME_None);
+	if (!TestNotNull(TEXT("Create a transient provider Blueprint"), ProviderBlueprint))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		CleanupTransientBlueprint(ProviderBlueprint);
+	};
+
+	const FName PrivateVariableName(TEXT("PrivateExternalValue"));
+	FEdGraphPinType PrivateVariableType;
+	PrivateVariableType.PinCategory = UEdGraphSchema_K2::PC_Boolean;
+	if (!TestTrue(TEXT("Add a provider member variable"),
+		FBlueprintEditorUtils::AddMemberVariable(ProviderBlueprint, PrivateVariableName, PrivateVariableType)))
+	{
+		return false;
+	}
+	FBlueprintEditorUtils::SetBlueprintVariableMetaData(
+		ProviderBlueprint, PrivateVariableName, nullptr, FBlueprintMetadata::MD_Private, TEXT("true"));
+	FKismetEditorUtilities::CompileBlueprint(ProviderBlueprint);
+	if (!TestNotNull(TEXT("Compile the transient provider Blueprint"), ProviderBlueprint->GeneratedClass.Get()))
+	{
+		return false;
+	}
+	FProperty* PrivateProperty = FindFProperty<FProperty>(ProviderBlueprint->GeneratedClass, PrivateVariableName);
+	if (!TestNotNull(TEXT("Compiled provider exposes the private reflected property"), PrivateProperty))
+	{
+		return false;
+	}
+	TestTrue(TEXT("Provider property carries BlueprintPrivate metadata"),
+		PrivateProperty && PrivateProperty->GetBoolMetaData(FBlueprintMetadata::MD_Private));
+
+	UEdGraph* Graph = FBlueprintEditorUtils::CreateNewGraph(
+		Blueprint, TEXT("ExternalVariableTestGraph"), UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+	if (!TestNotNull(TEXT("Create a transient K2 graph"), Graph))
+	{
+		return false;
+	}
+	FBlueprintEditorUtils::AddUbergraphPage(Blueprint, Graph);
+
+	const FString BlueprintPath = Blueprint->GetPathName();
+	const FString GraphName = Graph->GetName();
+	const FString CharacterClassPath = ACharacter::StaticClass()->GetPathName();
+	const int32 InitialNodeCount = Graph->Nodes.Num();
+
+	const FString GetterGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, CharacterClassPath, TEXT("Tags"), false, 120, 240);
+	UK2Node_Variable* GetterNode = FindVariableNodeByGuid(Graph, GetterGuid);
+	TestTrue(TEXT("Getter returns a parseable non-empty GUID"), !GetterGuid.IsEmpty() && GetterNode != nullptr);
+	TestTrue(TEXT("Getter creates UK2Node_VariableGet"), GetterNode && GetterNode->IsA<UK2Node_VariableGet>());
+	TestTrue(TEXT("Getter node is transactional"), GetterNode && GetterNode->HasAnyFlags(RF_Transactional));
+	TestEqual(TEXT("Getter call adds exactly one production node"), Graph->Nodes.Num(), InitialNodeCount + 1);
+	TestEqual(TEXT("Getter preflight candidate is not a live graph-owned variable node"),
+		CountLiveGraphOwnedVariableNodes(Graph), 1);
+
+	if (GEditor)
+	{
+		TestTrue(TEXT("Undo getter transaction succeeds"), GEditor->UndoTransaction());
+		TestEqual(TEXT("Undo getter removes exactly its created node"), Graph->Nodes.Num(), InitialNodeCount);
+		TestNull(TEXT("Getter GUID is absent after Undo"), FindVariableNodeByGuid(Graph, GetterGuid));
+		TestTrue(TEXT("Redo getter transaction succeeds"), GEditor->RedoTransaction());
+	}
+	else
+	{
+		AddError(TEXT("GEditor is required for behavioral Undo/Redo coverage"));
+	}
+	GetterNode = FindVariableNodeByGuid(Graph, GetterGuid);
+	TestNotNull(TEXT("Redo restores the getter with the same GUID"), GetterNode);
+	TestTrue(TEXT("Redo restores the getter member reference"), GetterNode
+		&& GetterNode->VariableReference.GetMemberParentClass() == AActor::StaticClass()
+		&& GetterNode->VariableReference.GetMemberName() == GET_MEMBER_NAME_CHECKED(AActor, Tags));
+	TestTrue(TEXT("Redo restores getter target and value pins"), GetterNode
+		&& GetterNode->FindPin(TEXT("self"))
+		&& GetterNode->FindPin(TEXT("self"))->Direction == EGPD_Input
+		&& GetterNode->FindPin(TEXT("Tags"))
+		&& GetterNode->FindPin(TEXT("Tags"))->Direction == EGPD_Output);
+
+	const FString SetterGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, CharacterClassPath, TEXT("Tags"), true, 560, 360);
+	UK2Node_Variable* SetterNode = FindVariableNodeByGuid(Graph, SetterGuid);
+	TestTrue(TEXT("Setter returns a parseable non-empty GUID"), !SetterGuid.IsEmpty() && SetterNode != nullptr);
+	TestTrue(TEXT("Setter creates UK2Node_VariableSet"), SetterNode && SetterNode->IsA<UK2Node_VariableSet>());
+	TestTrue(TEXT("Setter node is transactional"), SetterNode && SetterNode->HasAnyFlags(RF_Transactional));
+	TestEqual(TEXT("Two successful calls add exactly two production nodes"), Graph->Nodes.Num(), InitialNodeCount + 2);
+	TestEqual(TEXT("Setter preflight candidate is not a live graph-owned variable node"),
+		CountLiveGraphOwnedVariableNodes(Graph), 2);
+
+	if (GEditor)
+	{
+		TestTrue(TEXT("Undo setter transaction succeeds"), GEditor->UndoTransaction());
+		TestEqual(TEXT("Undo setter leaves the getter intact"), Graph->Nodes.Num(), InitialNodeCount + 1);
+		TestNull(TEXT("Setter GUID is absent after Undo"), FindVariableNodeByGuid(Graph, SetterGuid));
+		TestNotNull(TEXT("Getter survives setter Undo"), FindVariableNodeByGuid(Graph, GetterGuid));
+		TestTrue(TEXT("Redo setter transaction succeeds"), GEditor->RedoTransaction());
+	}
+	SetterNode = FindVariableNodeByGuid(Graph, SetterGuid);
+	TestNotNull(TEXT("Redo restores the setter with the same GUID"), SetterNode);
+	TestTrue(TEXT("Redo restores the setter member reference"), SetterNode
+		&& SetterNode->VariableReference.GetMemberParentClass() == AActor::StaticClass()
+		&& SetterNode->VariableReference.GetMemberName() == GET_MEMBER_NAME_CHECKED(AActor, Tags));
+	TestTrue(TEXT("Redo restores setter target and value pins"), SetterNode
+		&& SetterNode->FindPin(TEXT("self"))
+		&& SetterNode->FindPin(TEXT("self"))->Direction == EGPD_Input
+		&& SetterNode->FindPin(TEXT("Tags"))
+		&& SetterNode->FindPin(TEXT("Tags"))->Direction == EGPD_Input);
+
+	for (const TPair<UK2Node_Variable*, bool>& Case : {
+		TPair<UK2Node_Variable*, bool>(GetterNode, false),
+		TPair<UK2Node_Variable*, bool>(SetterNode, true)})
+	{
+		UK2Node_Variable* Node = Case.Key;
+		const bool bIsSetter = Case.Value;
+		if (!Node)
+		{
+			continue;
+		}
+
+		TestTrue(TEXT("External variable node remains transactional after Redo"), Node->HasAnyFlags(RF_Transactional));
+		TestFalse(TEXT("External variable reference is not self context"), Node->VariableReference.IsSelfContext());
+		TestEqual(TEXT("Inherited Tags reference binds to its declaring AActor class"),
+			Node->VariableReference.GetMemberParentClass(), AActor::StaticClass());
+		TestEqual(TEXT("External variable reference keeps the property name"),
+			Node->VariableReference.GetMemberName(), GET_MEMBER_NAME_CHECKED(AActor, Tags));
+
+		UEdGraphPin* SelfPin = Node->FindPin(TEXT("self"));
+		UEdGraphPin* ValuePin = Node->FindPin(TEXT("Tags"));
+		TestNotNull(TEXT("External node has a self target pin"), SelfPin);
+		TestNotNull(TEXT("External node has a Tags value pin"), ValuePin);
+		if (SelfPin)
+		{
+			TestEqual(TEXT("Self target pin is an input"), SelfPin->Direction, EGPD_Input);
+		}
+		if (ValuePin)
+		{
+			TestEqual(TEXT("Value pin direction matches getter or setter"),
+				ValuePin->Direction, bIsSetter ? EGPD_Input : EGPD_Output);
+		}
+	}
+
+	if (GetterNode)
+	{
+		TestEqual(TEXT("Getter X position is preserved"), GetterNode->NodePosX, 120);
+		TestEqual(TEXT("Getter Y position is preserved"), GetterNode->NodePosY, 240);
+	}
+	if (SetterNode)
+	{
+		TestEqual(TEXT("Setter X position is preserved"), SetterNode->NodePosX, 560);
+		TestEqual(TEXT("Setter Y position is preserved"), SetterNode->NodePosY, 360);
+	}
+
+	const int32 NodeCountBeforeFailures = Graph->Nodes.Num();
+	// 拒绝路径按契约记录警告；将其声明为预期输出，避免成功的失败测试污染 Automation 结果。
+	// Rejection paths log warnings by contract; declare them expected so successful negative coverage keeps a clean report.
+	AddExpectedError(TEXT("AddExternalVariableNode failed:"), EAutomationExpectedErrorFlags::Contains, 5);
+	AddExpectedError(TEXT("Failed to find object 'Class /Script/Engine.DefinitelyMissingOwnerClass'"),
+		EAutomationExpectedErrorFlags::Contains, 1);
+
+	const FString ProviderClassPath = ProviderBlueprint->GeneratedClass->GetPathName();
+	const FString PrivateGetterGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, ProviderClassPath, PrivateVariableName.ToString(), false, 0, 0);
+	TestTrue(TEXT("Getter rejects an unrelated provider's BlueprintPrivate property"), PrivateGetterGuid.IsEmpty());
+	TestEqual(TEXT("Private getter rejection leaves node count unchanged"), Graph->Nodes.Num(), NodeCountBeforeFailures);
+
+	const FString PrivateSetterGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, ProviderClassPath, PrivateVariableName.ToString(), true, 0, 0);
+	TestTrue(TEXT("Setter rejects an unrelated provider's BlueprintPrivate property"), PrivateSetterGuid.IsEmpty());
+	TestEqual(TEXT("Private setter rejection leaves node count unchanged"), Graph->Nodes.Num(), NodeCountBeforeFailures);
+
+	const FString ReadOnlyGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, CharacterClassPath, TEXT("InitialLifeSpan"), true, 0, 0);
+	TestTrue(TEXT("Setter rejects BlueprintReadOnly InitialLifeSpan"), ReadOnlyGuid.IsEmpty());
+	TestEqual(TEXT("Read-only rejection leaves node count unchanged"), Graph->Nodes.Num(), NodeCountBeforeFailures);
+
+	const FString MissingPropertyGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, CharacterClassPath, TEXT("DefinitelyMissingProperty"), false, 0, 0);
+	TestTrue(TEXT("Missing property returns an empty GUID"), MissingPropertyGuid.IsEmpty());
+	TestEqual(TEXT("Missing property leaves node count unchanged"), Graph->Nodes.Num(), NodeCountBeforeFailures);
+
+	const FString MissingClassGuid = UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+		BlueprintPath, GraphName, TEXT("/Script/Engine.DefinitelyMissingOwnerClass"), TEXT("Tags"), false, 0, 0);
+	TestTrue(TEXT("Missing owner class returns an empty GUID"), MissingClassGuid.IsEmpty());
+	TestEqual(TEXT("Missing owner class leaves node count unchanged"), Graph->Nodes.Num(), NodeCountBeforeFailures);
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeBlueprintLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeBlueprintLibrary.cpp
@@ -77,8 +77,10 @@
 #include "K2Node_Tunnel.h"
 #include "K2Node_Composite.h"
 #include "Misc/SecureHash.h"
+#include "Misc/ScopeExit.h"
 #include "UObject/Script.h"
 #include "UObject/Stack.h"
+#include "ScopedTransaction.h"
 #if !UE_VERSION_OLDER_THAN(5, 4, 0)
 #include "Blueprint/BlueprintExceptionInfo.h"
 #endif
@@ -96,6 +98,8 @@
 #include "InputMappingContext.h"
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogUnrealBridgeBlueprintGraph, Log, All);
 
 // ─── Helpers ─────────────────────────────────────────────────
 
@@ -2134,6 +2138,130 @@ FString UUnrealBridgeBlueprintLibrary::AddVariableNode(
 		: (UK2Node_Variable*)NewObject<UK2Node_VariableGet>(Graph);
 	Node->CreateNewGuid();
 	Node->VariableReference.SetSelfMember(VarFName);
+	Node->NodePosX = NodePosX;
+	Node->NodePosY = NodePosY;
+	Graph->AddNode(Node, false, false);
+	Node->PostPlacedNewNode();
+	Node->AllocateDefaultPins();
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
+	return Node->NodeGuid.ToString(EGuidFormats::Digits);
+}
+
+FString UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(
+	const FString& BlueprintPath, const FString& GraphName,
+	const FString& OwnerClassPath, const FString& VariableName, bool bIsSet,
+	int32 NodePosX, int32 NodePosY)
+{
+	const TCHAR* Operation = bIsSet ? TEXT("Set") : TEXT("Get");
+	const auto Fail = [&](const TCHAR* Reason) -> FString
+	{
+		UE_LOG(LogUnrealBridgeBlueprintGraph, Warning,
+			TEXT("AddExternalVariableNode failed: Reason='%s' Blueprint='%s' Graph='%s' OwnerClass='%s' Property='%s' Operation='%s'"),
+			Reason, *BlueprintPath, *GraphName, *OwnerClassPath, *VariableName, Operation);
+		return FString();
+	};
+
+	if (OwnerClassPath.TrimStartAndEnd().IsEmpty())
+	{
+		return Fail(TEXT("OwnerClassPath must be explicitly provided"));
+	}
+	if (VariableName.TrimStartAndEnd().IsEmpty())
+	{
+		return Fail(TEXT("VariableName must not be empty"));
+	}
+
+	UBlueprint* BP = LoadBP(BlueprintPath);
+	if (!BP)
+	{
+		return Fail(TEXT("Blueprint could not be loaded"));
+	}
+
+	UEdGraph* Graph = BridgeBlueprintGraphWriteImpl::FindGraphByName(BP, GraphName);
+	if (!Graph)
+	{
+		return Fail(TEXT("Graph was not found"));
+	}
+	if (!Cast<UEdGraphSchema_K2>(Graph->GetSchema()))
+	{
+		return Fail(TEXT("Graph does not use a K2 schema"));
+	}
+
+	UClass* RequestedOwnerClass = BridgeBlueprintGraphWriteImpl::ResolveTargetClass(BP, OwnerClassPath);
+	if (!RequestedOwnerClass)
+	{
+		return Fail(TEXT("Owner class could not be resolved"));
+	}
+
+	const FName VarFName(*VariableName);
+	FProperty* Property = FindFProperty<FProperty>(RequestedOwnerClass, VarFName);
+	if (!Property)
+	{
+		return Fail(TEXT("Property was not found on the owner class"));
+	}
+	// 使用引擎的权威访问检查，让 consumer Blueprint 的身份参与 private/read-only/visible 判定。
+	// Use the engine's canonical access checks so the consumer Blueprint identity participates in private/read-only/visible decisions.
+	if (bIsSet)
+	{
+		const FBlueprintEditorUtils::EPropertyWritableState WritableState =
+			FBlueprintEditorUtils::IsPropertyWritableInBlueprint(BP, Property);
+		if (WritableState != FBlueprintEditorUtils::EPropertyWritableState::Writable)
+		{
+			return Fail(TEXT("Property is not writable from the consumer Blueprint"));
+		}
+	}
+	else
+	{
+		const FBlueprintEditorUtils::EPropertyReadableState ReadableState =
+			FBlueprintEditorUtils::IsPropertyReadableInBlueprint(BP, Property);
+		if (ReadableState != FBlueprintEditorUtils::EPropertyReadableState::Readable)
+		{
+			return Fail(TEXT("Property is not readable from the consumer Blueprint"));
+		}
+	}
+
+	UClass* DeclaringOwnerClass = Property->GetOwner<UClass>();
+	if (!DeclaringOwnerClass)
+	{
+		return Fail(TEXT("Property does not have a declaring UClass"));
+	}
+
+	// 先用未加入图的候选节点验证 K2 引脚契约，确保所有失败都发生在事务和图修改之前。
+	// Validate the K2 pin contract on an unregistered candidate so every failure precedes the transaction and graph mutation.
+	UK2Node_Variable* CandidateNode = bIsSet
+		? static_cast<UK2Node_Variable*>(NewObject<UK2Node_VariableSet>(Graph, NAME_None, RF_Transient))
+		: static_cast<UK2Node_Variable*>(NewObject<UK2Node_VariableGet>(Graph, NAME_None, RF_Transient));
+	ON_SCOPE_EXIT
+	{
+		CandidateNode->MarkAsGarbage();
+	};
+	CandidateNode->VariableReference.SetExternalMember(VarFName, DeclaringOwnerClass);
+	CandidateNode->AllocateDefaultPins();
+
+	UEdGraphPin* TargetPin = CandidateNode->FindPin(TEXT("self"));
+	UEdGraphPin* ValuePin = CandidateNode->FindPin(VarFName);
+	const EEdGraphPinDirection ExpectedValueDirection = bIsSet ? EGPD_Input : EGPD_Output;
+	if (!TargetPin || TargetPin->Direction != EGPD_Input)
+	{
+		return Fail(TEXT("Variable node did not allocate the required 'self' input pin"));
+	}
+	if (!ValuePin || ValuePin->Direction != ExpectedValueDirection)
+	{
+		return Fail(TEXT("Variable node did not allocate a value pin with the expected direction"));
+	}
+
+	const FScopedTransaction Transaction(NSLOCTEXT(
+		"UnrealBridge", "AddExternalVariableNode", "UnrealBridge: Add External Variable Node"));
+	BP->Modify();
+	Graph->Modify();
+
+	UK2Node_Variable* Node = bIsSet
+		? static_cast<UK2Node_Variable*>(NewObject<UK2Node_VariableSet>(Graph))
+		: static_cast<UK2Node_Variable*>(NewObject<UK2Node_VariableGet>(Graph));
+	Node->SetFlags(RF_Transactional);
+	Node->Modify();
+	Node->CreateNewGuid();
+	Node->VariableReference.SetExternalMember(VarFName, DeclaringOwnerClass);
 	Node->NodePosX = NodePosX;
 	Node->NodePosY = NodePosY;
 	Graph->AddNode(Node, false, false);

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeBlueprintLibrary.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeBlueprintLibrary.h
@@ -1756,6 +1756,19 @@ public:
 		const FString& VariableName, bool bIsSet, int32 NodePosX, int32 NodePosY);
 
 	/**
+	 * 为显式外部类中当前蓝图可访问的属性添加 VariableGet（bIsSet=false）或 VariableSet（bIsSet=true）节点。
+	 * Add a VariableGet (bIsSet=false) or VariableSet (bIsSet=true) node for a property that the
+	 * current Blueprint may access on an explicit external class.
+	 * @param OwnerClassPath 必须为非空类路径；继承属性会绑定到实际声明该属性的类，外部蓝图不能访问 BlueprintPrivate 属性。
+	 *                       Must be a non-empty class path; inherited properties bind to their declaring class, and unrelated Blueprints cannot access BlueprintPrivate properties.
+	 * @return 成功时返回节点 GUID，失败时记录诊断并返回空字符串。Node GUID on success; logs a diagnostic and returns an empty string on failure.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Blueprint")
+	static FString AddExternalVariableNode(const FString& BlueprintPath, const FString& GraphName,
+		const FString& OwnerClassPath, const FString& VariableName, bool bIsSet,
+		int32 NodePosX, int32 NodePosY);
+
+	/**
 	 * Connect two pins identified by node GUID + pin name. Uses the K2 schema's TryCreateConnection
 	 * so it respects type coercion and exec-link rules.
 	 * @return true on success; false when nodes/pins missing or types incompatible.

--- a/tools/test_add_external_variable_node_contract.py
+++ b/tools/test_add_external_variable_node_contract.py
@@ -1,0 +1,180 @@
+"""Deterministic source-contract tests for AddExternalVariableNode."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = ROOT / "Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeBlueprintLibrary.h"
+SOURCE = ROOT / "Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeBlueprintLibrary.cpp"
+REFERENCE = ROOT / ".claude/skills/unreal-bridge/references/bridge-blueprint-api.md"
+MANIFEST = ROOT / ".claude/skills/unreal-bridge/scripts/bridge_manifest.json"
+WRAPPER = ROOT / "Plugin/UnrealBridge/Content/Python/unreal_bridge.py"
+AUTOMATION = (
+    ROOT
+    / "Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests"
+    / "UnrealBridgeAddExternalVariableNodeTests.cpp"
+)
+
+
+def extract_function(source: str, signature: str) -> str:
+    """Return one complete C++ function using balanced braces."""
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"Unbalanced function body for {signature}")
+
+
+class AddExternalVariableNodeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.header = HEADER.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        cls.reference = REFERENCE.read_text(encoding="utf-8")
+        cls.manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.wrapper = WRAPPER.read_text(encoding="utf-8")
+        cls.automation = AUTOMATION.read_text(encoding="utf-8")
+        cls.function = extract_function(
+            cls.source,
+            "FString UUnrealBridgeBlueprintLibrary::AddExternalVariableNode(",
+        )
+
+    def test_reflected_api_is_adjacent_to_self_variable_api(self) -> None:
+        declaration = re.compile(
+            r"AddVariableNode\([^;]+;\s*/\*\*.*?"
+            r"UFUNCTION\(BlueprintCallable, Category = \"UnrealBridge\|Blueprint\"\)\s*"
+            r"static FString AddExternalVariableNode\(",
+            re.DOTALL,
+        )
+        self.assertRegex(self.header, declaration)
+        self.assertIn("const FString& OwnerClassPath", self.header)
+
+    def test_all_failures_are_pre_mutation_and_diagnostic(self) -> None:
+        transaction = self.function.index("FScopedTransaction")
+        for required_validation in (
+            "OwnerClassPath.TrimStartAndEnd().IsEmpty()",
+            "Cast<UEdGraphSchema_K2>(Graph->GetSchema())",
+            "FindFProperty<FProperty>(RequestedOwnerClass, VarFName)",
+            "FBlueprintEditorUtils::IsPropertyWritableInBlueprint(BP, Property)",
+            "FBlueprintEditorUtils::IsPropertyReadableInBlueprint(BP, Property)",
+            "Property->GetOwner<UClass>()",
+            'FindPin(TEXT("self"))',
+            "CandidateNode->FindPin(VarFName)",
+        ):
+            self.assertLess(self.function.index(required_validation), transaction)
+        self.assertEqual(1, self.function.count("FScopedTransaction"))
+        self.assertNotIn("return FString();", self.function.replace("return FString();", "", 1))
+        self.assertIn("UE_LOG(LogUnrealBridgeBlueprintGraph, Warning", self.function)
+        for diagnostic_field in (
+            "Blueprint='%s'",
+            "Graph='%s'",
+            "OwnerClass='%s'",
+            "Property='%s'",
+            "Operation='%s'",
+            "Reason='%s'",
+        ):
+            self.assertIn(diagnostic_field, self.function)
+
+    def test_mutation_uses_declaring_owner_and_one_transaction(self) -> None:
+        transaction = self.function.index("FScopedTransaction")
+        mutation = self.function[transaction:]
+        self.assertIn(
+            "VariableReference.SetExternalMember(VarFName, DeclaringOwnerClass)",
+            mutation,
+        )
+        self.assertNotIn(
+            "VariableReference.SetExternalMember(VarFName, RequestedOwnerClass)",
+            self.function,
+        )
+        self.assertIn("BP->Modify();", mutation)
+        self.assertIn("Graph->Modify();", mutation)
+        self.assertIn("Node->SetFlags(RF_Transactional);", mutation)
+        self.assertIn("Node->Modify();", mutation)
+        self.assertIn("FBlueprintEditorUtils::MarkBlueprintAsModified(BP);", mutation)
+        self.assertIn("Node->NodeGuid.ToString(EGuidFormats::Digits)", mutation)
+
+    def test_validation_candidate_is_transient_and_scope_cleaned(self) -> None:
+        transaction = self.function.index("FScopedTransaction")
+        preflight = self.function[:transaction]
+        self.assertIn("RF_Transient", preflight)
+        self.assertIn("ON_SCOPE_EXIT", preflight)
+        self.assertIn("CandidateNode->MarkAsGarbage();", preflight)
+
+    def test_automation_covers_private_access_and_behavioral_undo_redo(self) -> None:
+        for required in (
+            "FBlueprintMetadata::MD_Private",
+            "PrivateGetterGuid",
+            "PrivateSetterGuid",
+            "GEditor->UndoTransaction()",
+            "GEditor->RedoTransaction()",
+            "HasAnyFlags(RF_Transactional)",
+            "CountLiveGraphOwnedVariableNodes",
+            "EInternalObjectFlags::Garbage",
+            "Getter GUID is absent after Undo",
+            "Redo restores the getter with the same GUID",
+            "Redo restores getter target and value pins",
+            "Setter GUID is absent after Undo",
+            "Redo restores the setter with the same GUID",
+            "Redo restores setter target and value pins",
+        ):
+            self.assertIn(required, self.automation)
+
+    def test_generated_surfaces_match_the_reflected_signature(self) -> None:
+        function = self.manifest["libraries"]["UnrealBridgeBlueprintLibrary"]["functions"][
+            "add_external_variable_node"
+        ]
+        self.assertEqual(
+            [parameter["name"] for parameter in function["params"]],
+            [
+                "blueprint_path",
+                "graph_name",
+                "owner_class_path",
+                "variable_name",
+                "is_set",
+                "node_pos_x",
+                "node_pos_y",
+            ],
+        )
+        self.assertEqual(function["returns"], "str")
+        self.assertIn(
+            "def add_external_variable_node(*, blueprint_path, graph_name, "
+            "owner_class_path, variable_name, is_set, node_pos_x, node_pos_y):",
+            self.wrapper,
+        )
+
+    def test_reference_documents_runtime_contract(self) -> None:
+        section_start = self.reference.index("### add_external_variable_node(")
+        section_end = self.reference.index("\n### ", section_start + 5)
+        section = self.reference[section_start:section_end]
+        self.assertIn(
+            "add_external_variable_node(blueprint_path, graph_name, owner_class_path, "
+            "variable_name, is_set, node_pos_x, node_pos_y)",
+            section,
+        )
+        for expected in (
+            "cannot be empty",
+            "canonical Blueprint access rules",
+            "Blueprint-private",
+            "Blueprint-read-only",
+            "actually declares it",
+            "single undo transaction",
+            "does not compile automatically",
+            "`self`",
+            "`Output_Get`",
+        ):
+            self.assertIn(expected, section)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add one explicit Blueprint graph primitive:

```text
add_external_variable_node(
  blueprint_path, graph_name, owner_class_path, variable_name,
  is_set, node_pos_x, node_pos_y
) -> node GUID
```

It creates an external Variable Get or Set node without guessing identity from the action database. The caller supplies the requested owner class and property; inherited properties bind to their actual declaring class.

## Safety contract

Before any graph mutation the implementation validates:

- Blueprint, K2 graph and schema
- owner class and reflected property
- consumer-aware canonical Blueprint readable/writable access (including unrelated `BlueprintPrivate` rejection)
- getter/setter target and value pin contracts

Preflight candidates are transient and scope-cleaned. Success uses one editor transaction and marks the Blueprint modified; it does not connect pins, compile, or save. Failures return an empty GUID and leave the graph unchanged with a contextual diagnostic.

## Generated surfaces

- reflected UFUNCTION
- generated manifest entry
- kwargs-only Python wrapper
- Blueprint API reference with exact reflected parameter names

## Validation

- Python contract/discovery/modal tests: 15/15 pass
- Python compile: pass
- UE 5.6 BuildPlugin: 81/81 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 BuildPlugin: 81/81 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 Automation `UnrealBridge.Blueprint.AddExternalVariableNode.Transient`: 1 succeeded, 0 failed, 0 warnings/not-run, Queue Empty

The transient Automation test covers inherited declaring-owner binding, getter/setter pins/GUID/position, unrelated `BlueprintPrivate`, read-only/missing failures, candidate cleanup, and separate behavioral Undo/Redo of getter and setter transactions.

## Compatibility / remaining coverage

Built on UE 5.6 and 5.7. UE 5.3-5.5 and 5.8 were not locally available. No disk save/reload or full generated-wrapper-authored business graph was exercised; the API intentionally leaves compile/save to the caller.
