### PR TITLE
feat: require endpoint instance preconditions (stacked on #6)

### DIFF
--- a/.claude/skills/unreal-bridge/SKILL.md
+++ b/.claude/skills/unreal-bridge/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash Read Write Edit Glob Grep Monitor
 
 # UnrealBridge
 
-Execute Python directly inside a running UE 5.3+ editor. Auto-discovery sends paired UDP probes to LAN multicast (`239.255.42.99:9876`) and local loopback (`127.0.0.1:9876`); responses are de-duplicated by editor PID. The TCP data port is OS-assigned per editor.
+Execute Python directly inside a running UE 5.3+ editor. Protocol-v2 auto-discovery sends paired UDP probes to LAN multicast (`239.255.42.99:9876`) and local loopback (`127.0.0.1:9876`); malformed replies are skipped independently, valid responses are de-duplicated by Server-start UUID, and wildcard binds use the UDP response source IP. The six exact commands are the minimum required capability set, so unique future capabilities remain forward-compatible. Every bounded TCP response is rechecked against the frozen identity. The TCP data port is OS-assigned per editor.
 
 ## Preconditions
 
@@ -16,7 +16,7 @@ If `bridge.py` returns `discovery: no UnrealBridge editors found`, walk these in
 2. **Plugin enabled** — check `<UEProject>/<Project>.uproject` `"Plugins"` block for `{"Name":"UnrealBridge", "Enabled":false}` and flip if present.
 3. **Editor up and ready** — `bridge.py ping` returns `"ready": true`. `false` means MainFrame still loading; wait 10–60s.
 
-The loopback probe keeps local discovery working when multicast is blocked by a VPN, virtual NIC, or Windows firewall policy. Last resort if UDP discovery itself is blocked: use `--endpoint=127.0.0.1:<port>` from the editor log line `LogUnrealBridge: Listening on 127.0.0.1:<port>`. Python 3.7+ stdlib only.
+The loopback probe keeps local discovery working when multicast is blocked by a VPN, virtual NIC, or Windows firewall policy. Direct mode is intentionally fail-closed: `--endpoint`, `--instance-id`, `--expected-pid`, and `--expected-project-path` (or matching `UNREAL_BRIDGE_*` variables) are one inseparable tuple. Copy the identity values verbatim from one discovery response or Server startup line; `project_path` is case- and representation-sensitive on every OS. A host/port alone can be stale and is never used as a legacy fallback. Python 3.7+ stdlib only.
 
 ## Waiting for the editor to become ready (post-launch / post-relaunch)
 
@@ -90,7 +90,7 @@ python "${CLAUDE_SKILL_DIR}/scripts/bridge.py" [options] <command> [args]
 | `list-editors` | Print every editor that responded to a discovery probe |
 | `wait-compile <material>` / `wait-pose-index <psd>` | Client-side polling helpers |
 
-Optional flags: `--project=<name|path>` (disambiguate when >1 editors run; or env `UNREAL_BRIDGE_PROJECT`), `--endpoint=host:port`, `--token=<secret>`, `--timeout=<s>`, `--json`, `--no-preflight`.
+Discovery-mode optional flags: `--project=<name|path>` (disambiguate when >1 editors run; or env `UNREAL_BRIDGE_PROJECT`), `--token=<secret>`, `--timeout=<s>`, `--json`, `--no-preflight`. Direct mode requires the complete `--endpoint=host:port --instance-id=<uuid> --expected-pid=<pid> --expected-project-path=<uproject>` tuple; none of its four fields is optional.
 
 ## Workflow
 

--- a/.claude/skills/unreal-bridge/references/bridge-editor-api.md
+++ b/.claude/skills/unreal-bridge/references/bridge-editor-api.md
@@ -8,13 +8,13 @@ Editor session control: state query, asset open/save, Content Browser, viewport,
 
 These are **server-level** commands, not Library functions — they're handled directly by `FUnrealBridgeServer::HandleClient` and bypass the FTSTicker exec queue. Use them when an `exec` is hung and you need to know *why* without queueing behind the stuck script.
 
-Each is a separate TCP connection (workers are per-connection, capped at 16). Send via `bridge.py` subcommand or by hand-crafting the JSON request:
+Each is a separate TCP connection (workers are per-connection, capped at 16). Prefer the `bridge.py` subcommand. A hand-crafted request must use protocol v2: `{"command":"exact_<name>","expected":{"protocol_version":2,"instance_id":"...","pid":...,"project_path":"..."},"request":{...}}`. Copy every identity value, including the case and separators of `project_path`, verbatim from one discovery response or Server startup line. The production dispatcher rejects malformed identity/request objects and legacy or unknown commands before any command body or GameThread dispatch.
 
-| Command JSON | CLI | Purpose |
+| Exact command | CLI | Purpose |
 |---|---|---|
-| `{"command":"ping"}` | `bridge.py ping` | TCP-only liveness — proves the server process and accept loop are alive. Returns `pong` plus `ready: bool` (false during the editor's startup window before main frame creation). |
-| `{"command":"gamethread_ping","timeout":2.0}` | `bridge.py gamethread-ping [--probe-timeout S]` | GameThread liveness — dispatches a no-op `AsyncTask(GameThread)` and waits up to `timeout` seconds (default 2s, max 10s). Response includes `latency_ms`. |
-| `{"command":"debug_resume"}` | `bridge.py resume` | Recover from a stuck Blueprint breakpoint. Calls `FKismetDebugUtilities::RequestAbortingExecution` + `FSlateApplication::LeaveDebuggingMode` via `AsyncTask(GameThread)`. Fire-and-forget. |
+| `exact_ping` | `bridge.py ping` | TCP-only liveness — proves the server process and accept loop are alive. Returns `pong` plus `ready: bool` (false during the editor's startup window before main frame creation). |
+| `exact_gamethread_ping` with `request.timeout` | `bridge.py gamethread-ping [--probe-timeout S]` | GameThread liveness — dispatches a no-op `AsyncTask(GameThread)` and waits up to `timeout` seconds (default 2s, max 10s). Response includes `latency_ms`. |
+| `exact_debug_resume` | `bridge.py resume` | Recover from a stuck Blueprint breakpoint. Calls `FKismetDebugUtilities::RequestAbortingExecution` + `FSlateApplication::LeaveDebuggingMode` via `AsyncTask(GameThread)`. Fire-and-forget. |
 
 ### `gamethread_ping` diagnostic table
 

--- a/.claude/skills/unreal-bridge/scripts/bridge.py
+++ b/.claude/skills/unreal-bridge/scripts/bridge.py
@@ -25,13 +25,17 @@ Useful for post-hoc audit and failure-mode analysis.
 
 Discovery overrides (rarely needed):
     --project=<name|path>      Pick one of multiple running editors
-    --endpoint=host:port       Skip discovery entirely, connect direct
+    --endpoint=host:port       Skip discovery; requires exact identity flags below
+    --instance-id=<uuid>       Frozen Server-start UUID for direct endpoint
+    --expected-pid=<pid>       Frozen editor PID for direct endpoint
+    --expected-project-path=... Exact discovery/startup project_path for direct endpoint
     --token=<secret>           Required when the server binds non-loopback
     --discovery-timeout=<ms>   Probe wait window (default: 800)
     --discovery-group=a.b.c.d:p  Override the multicast group
 
 Environment variable fallbacks:
     UNREAL_BRIDGE_PROJECT, UNREAL_BRIDGE_ENDPOINT, UNREAL_BRIDGE_TOKEN,
+    UNREAL_BRIDGE_INSTANCE_ID, UNREAL_BRIDGE_PID, UNREAL_BRIDGE_PROJECT_PATH,
     UNREAL_BRIDGE_DISCOVERY_GROUP
 
 Protocol: length-prefixed JSON over TCP
@@ -57,6 +61,8 @@ try:
         DEFAULT_DISCOVERY_TIMEOUT_MS,
         DiscoveryError,
         Endpoint,
+        EXACT_CAPABILITIES,
+        PROTOCOL_VERSION,
         discover,
         load_token,
         select,
@@ -71,6 +77,8 @@ except ImportError:
         DEFAULT_DISCOVERY_TIMEOUT_MS,
         DiscoveryError,
         Endpoint,
+        EXACT_CAPABILITIES,
+        PROTOCOL_VERSION,
         discover,
         load_token,
         select,
@@ -82,14 +90,19 @@ DEFAULT_TIMEOUT = 30
 AUDIT_LOG_MAX_BYTES = 5 * 1024 * 1024   # 5 MB per file
 AUDIT_LOG_BACKUPS = 3                    # 4 files total (1 active + 3 backups) = 20 MB hard cap
 AUDIT_LOG_NAME = "exec.log"
+# 单个 TCP 响应帧的硬上限与 Server 请求上限一致，防止错误 endpoint 宣告无界读取。
+# Hard per-response-frame limit matching the Server request cap, preventing unbounded reads from a wrong endpoint.
+MAX_RESPONSE_FRAME_BYTES = 10 * 1024 * 1024
 
 
 # ── Resolution: turn CLI args into a (host, port, token, project_path) tuple ─
 
-def resolve_target(args) -> "tuple[str, int, str | None, str | None]":
+def resolve_target(args) -> "tuple[str, int, str | None, str | None, Endpoint]":
     """Figure out which editor to talk to.
 
-    Returns (host, port, token, project_path). project_path is the .uproject
+    Returns (host, port, token, project_path, identity). Identity is frozen
+    from protocol-v2 discovery or supplied explicitly for a direct endpoint.
+    project_path is the .uproject
     file path when discovery succeeded — used to locate the per-project audit
     log under Saved/UnrealBridge/. None when --endpoint skipped discovery.
 
@@ -98,14 +111,42 @@ def resolve_target(args) -> "tuple[str, int, str | None, str | None]":
       2. UDP multicast + local-loopback discovery, filtered by --project
          (or UNREAL_BRIDGE_PROJECT)
     """
-    # 1. Explicit endpoint — no discovery, no project_path.
+    # 显式 endpoint 也必须冻结精确的 Server-start identity，禁止只信任可复用端口。
+    # An explicit endpoint must also freeze Server-start identity; a reusable port is insufficient.
     endpoint_str = getattr(args, "endpoint", None) or os.environ.get("UNREAL_BRIDGE_ENDPOINT")
     if endpoint_str:
         if ":" not in endpoint_str:
             raise SystemExit(f"--endpoint must be host:port (got {endpoint_str!r})")
         host, port_s = endpoint_str.rsplit(":", 1)
         token = getattr(args, "token", None) or os.environ.get("UNREAL_BRIDGE_TOKEN")
-        return host, int(port_s), token, None
+        instance_id = (getattr(args, "instance_id", None)
+                       or os.environ.get("UNREAL_BRIDGE_INSTANCE_ID"))
+        project_path = (getattr(args, "expected_project_path", None)
+                        or os.environ.get("UNREAL_BRIDGE_PROJECT_PATH"))
+        pid_value = (getattr(args, "expected_pid", None)
+                     or os.environ.get("UNREAL_BRIDGE_PID"))
+        if not instance_id or not project_path or not pid_value:
+            raise SystemExit(
+                "--endpoint requires --instance-id, --expected-project-path, and "
+                "--expected-pid (or matching UNREAL_BRIDGE_* environment values); "
+                "direct legacy writes are not allowed"
+            )
+        identity = Endpoint(
+            protocol_version=PROTOCOL_VERSION,
+            instance_id=str(instance_id),
+            pid=int(pid_value),
+            project=os.path.splitext(os.path.basename(project_path))[0],
+            # wire project_path 必须逐字复制 discovery/startup 输出，不做平台等价改写。
+            # The wire project_path must be copied verbatim from discovery/startup output.
+            project_path=str(project_path),
+            engine_version="",
+            tcp_bind=host,
+            tcp_port=int(port_s),
+            token_fingerprint="",
+            capabilities=EXACT_CAPABILITIES,
+            response_host=host,
+        )
+        return host, int(port_s), token, identity.project_path, identity
 
     # 2. Discovery.
     project = getattr(args, "project", None) or os.environ.get("UNREAL_BRIDGE_PROJECT") or "*"
@@ -126,7 +167,7 @@ def resolve_target(args) -> "tuple[str, int, str | None, str | None]":
         ep = select(eps, project_filter=project if project != "*" else None)
         token = load_token(ep, explicit_token=getattr(args, "token", None)
                            or os.environ.get("UNREAL_BRIDGE_TOKEN"))
-        return ep.host, ep.port, token, ep.project_path or None
+        return ep.host, ep.port, token, ep.project_path or None, ep
     except DiscoveryError as e:
         raise SystemExit(f"discovery: {e}")
 
@@ -430,12 +471,88 @@ def _audit(project_path: "str | None", mode: str, src: "str | None",
 
 # ── Wire protocol helpers ─────────────────────────────────────────────────
 
-def send_request(host: str, port: int, payload: dict, timeout: float,
-                 token: "str | None" = None) -> dict:
-    """Send a JSON request; return the parsed response."""
+class EndpointIdentityError(ConnectionError):
+    """发现身份与实际 endpoint 不一致时失败。 / Raised when discovery identity and the connected endpoint disagree."""
+
+
+def _build_exact_payload(payload: dict, identity: Endpoint,
+                         token: "str | None" = None) -> dict:
+    """构建旧 Server 无法当作 Python 执行的 wire form。 / Build a wire form a legacy server cannot execute as Python."""
+    request_id = str(payload.get("id") or uuid.uuid4())
+    legacy_command = payload.get("command")
+    command = f"exact_{legacy_command}" if legacy_command else "exact_exec"
+    nested = {key: value for key, value in payload.items()
+              if key not in ("id", "command", "token")}
+    wire = {
+        "id": request_id,
+        "command": command,
+        "expected": {
+            "protocol_version": identity.protocol_version,
+            "instance_id": identity.instance_id,
+            "pid": identity.pid,
+            "project_path": identity.project_path,
+        },
+        "request": nested,
+    }
     if token:
-        payload = dict(payload)
-        payload.setdefault("token", token)
+        wire["token"] = token
+    return wire
+
+
+def _verify_response_identity(response: dict, identity: Endpoint) -> None:
+    """endpoint 复用与 discovery/TCP 竞态时 fail closed。 / Fail closed when endpoint reuse races discovery and TCP."""
+    if (type(response.get("protocol_version")) is not int
+            or type(response.get("pid")) is not int
+            or not isinstance(response.get("instance_id"), str)
+            or not isinstance(response.get("project_path"), str)):
+        raise EndpointIdentityError("endpoint response identity has invalid field types")
+    actual = (
+        response["protocol_version"], response["instance_id"],
+        response["pid"], response["project_path"],
+    )
+    expected = (
+        identity.protocol_version, identity.instance_id, identity.pid,
+        identity.project_path,
+    )
+    if actual != expected:
+        raise EndpointIdentityError(
+            f"endpoint identity mismatch: expected {expected!r}, got {actual!r}"
+        )
+
+
+class BridgeProtocolError(ConnectionError):
+    """响应帧违反边界或 JSON schema 时失败。 / Raised when a response frame violates bounds or its JSON schema."""
+
+
+def _validate_response_frame_length(frame_length: int) -> None:
+    """在读取/分配 body 前验证响应长度。 / Validate response length before reading or allocating its body."""
+    if frame_length <= 0 or frame_length > MAX_RESPONSE_FRAME_BYTES:
+        raise BridgeProtocolError(
+            f"invalid response frame length {frame_length}; "
+            f"expected 1..{MAX_RESPONSE_FRAME_BYTES} bytes"
+        )
+
+
+def _decode_response_frame(frame: bytes) -> dict:
+    """严格解码 UTF-8 JSON object。 / Strictly decode a UTF-8 JSON object."""
+    try:
+        response = json.loads(frame.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise BridgeProtocolError(f"response is not valid UTF-8: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise BridgeProtocolError(f"response is not valid JSON: {exc}") from exc
+    if not isinstance(response, dict):
+        raise BridgeProtocolError("response JSON root must be an object")
+    return response
+
+
+def send_request(host: str, port: int, payload: dict, timeout: float,
+                 token: "str | None" = None,
+                 identity: "Endpoint | None" = None) -> dict:
+    """发送 exact request 并复核响应身份。 / Send one exact request and verify the echoed Server-start identity."""
+    if identity is None:
+        raise EndpointIdentityError("exact endpoint identity is required; legacy fallback is disabled")
+    payload = _build_exact_payload(payload, identity, token=token)
     data = json.dumps(payload).encode("utf-8")
     header = struct.pack(">I", len(data))
 
@@ -446,8 +563,11 @@ def send_request(host: str, port: int, payload: dict, timeout: float,
 
         resp_header = _recv_all(sock, 4)
         resp_len = struct.unpack(">I", resp_header)[0]
+        _validate_response_frame_length(resp_len)
         resp_data = _recv_all(sock, resp_len)
-        return json.loads(resp_data.decode("utf-8"))
+        response = _decode_response_frame(resp_data)
+        _verify_response_identity(response, identity)
+        return response
 
 
 def _recv_all(sock: socket.socket, num_bytes: int) -> bytes:
@@ -521,7 +641,7 @@ def _print_modal(modal: dict, stream=None) -> None:
     print("\n".join(_modal_lines(modal)), file=stream)
 
 
-def _probe_modal(host: str, port: int, token: "str | None",
+def _probe_modal(host: str, port: int, token: "str | None", identity: Endpoint,
                  timeout: float = 4.0) -> "dict | None":
     """Best-effort bypass probe used after an exec timeout.
 
@@ -531,7 +651,7 @@ def _probe_modal(host: str, port: int, token: "str | None",
     """
     try:
         payload = {"id": str(uuid.uuid4()), "command": "modal_status"}
-        response = send_request(host, port, payload, timeout, token=token)
+        response = send_request(host, port, payload, timeout, token=token, identity=identity)
         modal = response.get("modal")
         if response.get("success") and isinstance(modal, dict):
             return modal
@@ -558,11 +678,11 @@ def _attach_modal_diagnostic(response: dict, modal: "dict | None") -> dict:
 
 
 def _send_modal_command(args, payload: dict) -> "tuple[int, dict]":
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     payload = dict(payload)
     payload.setdefault("id", str(uuid.uuid4()))
     try:
-        response = send_request(host, port, payload, min(max(args.timeout, 4.0), 15.0), token=token)
+        response = send_request(host, port, payload, min(max(args.timeout, 4.0), 15.0), token=token, identity=identity)
     except Exception as exc:
         response = {"success": False, "error": str(exc)}
         return 1, response
@@ -627,10 +747,10 @@ def cmd_modal_set_checkbox(args):
     return code
 
 def cmd_ping(args):
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     try:
         payload = {"id": str(uuid.uuid4()), "command": "ping"}
-        resp = send_request(host, port, payload, args.timeout, token=token)
+        resp = send_request(host, port, payload, args.timeout, token=token, identity=identity)
     except ConnectionRefusedError:
         if args.json:
             print(json.dumps({"success": False, "error": "Connection refused"}))
@@ -667,14 +787,14 @@ def cmd_ping(args):
 
 def cmd_gt_ping(args):
     """Probe whether the UE GameThread is responsive."""
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     payload = {
         "id": str(uuid.uuid4()),
         "command": "gamethread_ping",
         "timeout": args.probe_timeout,
     }
     try:
-        resp = send_request(host, port, payload, args.probe_timeout + 3.0, token=token)
+        resp = send_request(host, port, payload, args.probe_timeout + 3.0, token=token, identity=identity)
     except Exception as e:
         if args.json:
             print(json.dumps({"success": False, "error": str(e)}))
@@ -698,10 +818,10 @@ def cmd_gt_ping(args):
 
 
 def cmd_resume(args):
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     try:
         payload = {"id": str(uuid.uuid4()), "command": "debug_resume"}
-        resp = send_request(host, port, payload, args.timeout, token=token)
+        resp = send_request(host, port, payload, args.timeout, token=token, identity=identity)
     except Exception as e:
         if args.json:
             print(json.dumps({"success": False, "error": str(e)}))
@@ -745,12 +865,12 @@ def cmd_wait_compile(args):
         " 'ql': str(r.quality_level), 'err': str(r.error)}))\n"
     )
 
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     last = None
     while _time.time() < deadline:
         payload = {"id": str(uuid.uuid4()), "script": code, "timeout": 5}
         try:
-            resp = send_request(host, port, payload, 10.0, token=token)
+            resp = send_request(host, port, payload, 10.0, token=token, identity=identity)
         except Exception as e:
             if args.json:
                 print(json.dumps({"success": False, "error": f"transport: {e}"}))
@@ -828,12 +948,12 @@ def cmd_wait_pose_index(args):
         "print(json.dumps({'status': str(status)}))\n"
     )
 
-    host, port, token, _project_path = resolve_target(args)
+    host, port, token, _project_path, identity = resolve_target(args)
     last = None
     while _time.time() < deadline:
         payload = {"id": str(uuid.uuid4()), "script": code, "timeout": 5}
         try:
-            resp = send_request(host, port, payload, 10.0, token=token)
+            resp = send_request(host, port, payload, 10.0, token=token, identity=identity)
         except Exception as e:
             if args.json:
                 print(json.dumps({"success": False, "error": f"transport: {e}"}))
@@ -1039,14 +1159,14 @@ def _execute(args, code: str, mode: str = "exec", src: "str | None" = None) -> i
             for e in errs:
                 print(e, file=sys.stderr)
             try:
-                _, _, _, proj = resolve_target(args)
+                _, _, _, proj, _identity = resolve_target(args)
             except SystemExit:
                 proj = None
             _audit(proj, mode, src, code, ok=False,
                    err=f"preflight: {len(errs)} error(s); first: {errs[0].splitlines()[0]}")
             return 3  # 3 = preflight rejection (distinct from 1 = transport, 2 = arg)
 
-    host, port, token, project_path = resolve_target(args)
+    host, port, token, project_path, identity = resolve_target(args)
 
     # Wrap user code so AttributeError messages get enriched with valid-attrs
     # + did-you-mean before reaching the agent's stderr. UE engine API has
@@ -1061,7 +1181,7 @@ def _execute(args, code: str, mode: str = "exec", src: "str | None" = None) -> i
     }
 
     try:
-        resp = send_request(host, port, payload, args.timeout + 5, token=token)
+        resp = send_request(host, port, payload, args.timeout + 5, token=token, identity=identity)
     except ConnectionRefusedError:
         msg = (
             f"Cannot connect to {host}:{port}. "
@@ -1081,7 +1201,7 @@ def _execute(args, code: str, mode: str = "exec", src: "str | None" = None) -> i
             "success": False,
             "error": f"request timed out after {args.timeout + 5:g}s: {e}",
         }
-        _attach_modal_diagnostic(resp, _probe_modal(host, port, token))
+        _attach_modal_diagnostic(resp, _probe_modal(host, port, token, identity))
         if args.json:
             print(json.dumps(resp, ensure_ascii=False))
         else:
@@ -1103,7 +1223,7 @@ def _execute(args, code: str, mode: str = "exec", src: "str | None" = None) -> i
     # what blocked them and can make a semantic choice.
     if (not resp.get("success")
             and "exec timeout" in (resp.get("error") or "").lower()):
-        _attach_modal_diagnostic(resp, _probe_modal(host, port, token))
+        _attach_modal_diagnostic(resp, _probe_modal(host, port, token, identity))
 
     if args.json:
         print(json.dumps(resp, ensure_ascii=False))
@@ -1135,6 +1255,21 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         "--project",
         help="Select an editor by project name / path when multiple are running "
              "(or set UNREAL_BRIDGE_PROJECT).",
+    )
+    parser.add_argument(
+        "--instance-id",
+        help="Required with --endpoint: frozen Server-start UUID "
+             "(or UNREAL_BRIDGE_INSTANCE_ID).",
+    )
+    parser.add_argument(
+        "--expected-pid",
+        type=int,
+        help="Required with --endpoint: frozen editor PID (or UNREAL_BRIDGE_PID).",
+    )
+    parser.add_argument(
+        "--expected-project-path",
+        help="Required with --endpoint: exact project_path copied from discovery/startup "
+             "(or UNREAL_BRIDGE_PROJECT_PATH).",
     )
     parser.add_argument(
         "--token",

--- a/.claude/skills/unreal-bridge/scripts/bridge_discovery.py
+++ b/.claude/skills/unreal-bridge/scripts/bridge_discovery.py
@@ -4,29 +4,34 @@ Replaces the old "assume 127.0.0.1:9876" wiring: the client sends the same
 probe to the multicast group 239.255.42.99:9876 and to the local loopback
 responder. Editors on the same host or subnet that have the UnrealBridge
 plugin loaded answer with their project name + TCP bind + TCP port. The
-client de-duplicates responses by process id, then picks one (single match
+client de-duplicates responses by Server-start instance UUID, then picks one (single match
 → auto, multiple → by --project filter or error).
 
 Wire format:
 
     probe (client → group):
-        {"v":1, "type":"probe",
+        {"v":2, "type":"probe",
          "request_id": "<uuid>",
          "filter": {"project": "<name|path|*>"}}
 
     response (server → probe source):
-        {"v":1, "type":"response",
-         "request_id": "<uuid>",
-         "pid": 1234, "project": "MyGame",
+        {"v":2, "protocol_version":2, "type":"response",
+         "request_id":"<uuid>", "instance_id":"<uuid>",
+         "pid":1234, "project":"MyGame",
          "project_path": "C:/.../MyGame.uproject",
          "engine_version": "5.7.0",
          "tcp_bind": "127.0.0.1", "tcp_port": 54321,
-         "token_fingerprint": "a1b2c3d4e5f60718"}    # "" when no token
+         "token_fingerprint": "a1b2c3d4e5f60718",
+         "capabilities": ["exact_exec", ...]}    # minimum required set; unique extras allowed
+
+Malformed datagrams are discarded independently. For wildcard tcp_bind values,
+the response source IP becomes the TCP host instead of client loopback.
 """
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 import socket
@@ -42,11 +47,18 @@ DEFAULT_DISCOVERY_GROUP = "239.255.42.99"
 DEFAULT_DISCOVERY_PORT = 9876
 DEFAULT_DISCOVERY_TIMEOUT_MS = 800
 LOCAL_DISCOVERY_HOST = "127.0.0.1"
+PROTOCOL_VERSION = 2
+EXACT_CAPABILITIES = (
+    "exact_exec", "exact_ping", "exact_gamethread_ping",
+    "exact_debug_resume", "exact_modal_status", "exact_modal_action",
+)
 
 
 @dataclass
 class Endpoint:
-    """One running UnrealBridge editor, as seen via discovery."""
+    """discovery 冻结的一次精确 Server 启动。 / One exact Server start frozen from discovery."""
+    protocol_version: int
+    instance_id: str
     pid: int
     project: str
     project_path: str
@@ -54,12 +66,14 @@ class Endpoint:
     tcp_bind: str
     tcp_port: int
     token_fingerprint: str
+    capabilities: Tuple[str, ...]
+    response_host: str
 
     @property
     def host(self) -> str:
-        """Best host to connect to — loopback if the server reported 0.0.0.0."""
+        """通配 bind 使用响应源 IP；否则使用广告地址。 / Use response source IP for wildcard binds, otherwise the advertised address."""
         if self.tcp_bind in ("0.0.0.0", "::"):
-            return "127.0.0.1"
+            return self.response_host
         return self.tcp_bind
 
     @property
@@ -68,7 +82,8 @@ class Endpoint:
 
     def __str__(self) -> str:
         token = " [token]" if self.token_fingerprint else ""
-        return f"{self.project} @ {self.host}:{self.port} (pid {self.pid}){token}"
+        return (f"{self.project} @ {self.host}:{self.port} "
+                f"(pid {self.pid}, instance {self.instance_id}){token}")
 
 
 def _parse_group(group: str) -> Tuple[str, int]:
@@ -77,6 +92,82 @@ def _parse_group(group: str) -> Tuple[str, int]:
         addr, port = group.rsplit(":", 1)
         return addr, int(port)
     return group, DEFAULT_DISCOVERY_PORT
+
+
+def _parse_endpoint_response(resp, request_id: str, response_host: str) -> "Endpoint | None":
+    """严格解析单个响应；畸形数据只丢弃当前 datagram。 / Strictly parse one response; malformed data drops only that datagram."""
+    if not isinstance(resp, dict):
+        return None
+    if type(resp.get("v")) is not int or resp["v"] != PROTOCOL_VERSION:
+        return None
+    if (type(resp.get("protocol_version")) is not int
+            or resp["protocol_version"] != PROTOCOL_VERSION):
+        return None
+    if resp.get("type") != "response" or resp.get("request_id") != request_id:
+        return None
+
+    instance_id = resp.get("instance_id")
+    if not isinstance(instance_id, str) or not instance_id:
+        return None
+    try:
+        parsed_uuid = uuid.UUID(instance_id)
+    except (ValueError, AttributeError, TypeError):
+        return None
+    if str(parsed_uuid) != instance_id.lower() or instance_id != instance_id.lower():
+        return None
+
+    pid = resp.get("pid")
+    tcp_port = resp.get("tcp_port")
+    if type(pid) is not int or not (1 <= pid <= 2_147_483_647):
+        return None
+    if type(tcp_port) is not int or not (1 <= tcp_port <= 65_535):
+        return None
+
+    required_strings = ("project", "project_path", "engine_version", "tcp_bind", "token_fingerprint")
+    if any(not isinstance(resp.get(field), str) for field in required_strings):
+        return None
+    project = resp["project"]
+    project_path = resp["project_path"]
+    engine_version = resp["engine_version"]
+    tcp_bind = resp["tcp_bind"]
+    token_fingerprint = resp["token_fingerprint"]
+    if not project or not project_path or not engine_version or not tcp_bind:
+        return None
+    try:
+        ipaddress.ip_address(tcp_bind)
+        ipaddress.ip_address(response_host)
+    except ValueError:
+        return None
+    if token_fingerprint:
+        if (len(token_fingerprint) != 16
+                or token_fingerprint != token_fingerprint.lower()
+                or any(ch not in "0123456789abcdef" for ch in token_fingerprint)):
+            return None
+
+    raw_capabilities = resp.get("capabilities")
+    if not isinstance(raw_capabilities, list):
+        return None
+    if any(not isinstance(item, str) or not item for item in raw_capabilities):
+        return None
+    if len(set(raw_capabilities)) != len(raw_capabilities):
+        return None
+    capabilities = tuple(raw_capabilities)
+    if not set(EXACT_CAPABILITIES).issubset(capabilities):
+        return None
+
+    return Endpoint(
+        protocol_version=PROTOCOL_VERSION,
+        instance_id=instance_id,
+        pid=pid,
+        project=project,
+        project_path=project_path,
+        engine_version=engine_version,
+        tcp_bind=tcp_bind,
+        tcp_port=tcp_port,
+        token_fingerprint=token_fingerprint,
+        capabilities=capabilities,
+        response_host=response_host,
+    )
 
 
 def discover(project_filter: str = "*",
@@ -91,7 +182,7 @@ def discover(project_filter: str = "*",
     """
     request_id = str(uuid.uuid4())
     probe_payload = json.dumps({
-        "v": 1,
+        "v": PROTOCOL_VERSION,
         "type": "probe",
         "request_id": request_id,
         "filter": {"project": project_filter or "*"},
@@ -108,7 +199,7 @@ def discover(project_filter: str = "*",
         # NICs, or Public firewall policy even while LAN multicast remains
         # useful. Send the identical request from the same ephemeral socket to
         # loopback as a local-only fallback. Both responders reply to this
-        # socket and the collection loop de-duplicates them by editor PID.
+        # socket and the collection loop de-duplicates them by Server-start UUID.
         probe_targets = [(group, group_port)]
         loopback_target = (LOCAL_DISCOVERY_HOST, group_port)
         if loopback_target not in probe_targets:
@@ -126,7 +217,7 @@ def discover(project_filter: str = "*",
 
         deadline = time.monotonic() + (timeout_ms / 1000.0)
         results: List[Endpoint] = []
-        seen_pids: set = set()
+        seen_instances: set = set()
 
         while True:
             remaining = deadline - time.monotonic()
@@ -134,33 +225,24 @@ def discover(project_filter: str = "*",
                 break
             sock.settimeout(remaining)
             try:
-                data, _addr = sock.recvfrom(64 * 1024)
+                data, source_addr = sock.recvfrom(64 * 1024)
             except socket.timeout:
                 break
 
             try:
                 resp = json.loads(data.decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError):
+                response_host = source_addr[0]
+                endpoint = _parse_endpoint_response(resp, request_id, response_host)
+            except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError, OverflowError, IndexError):
+                endpoint = None
+            if endpoint is None:
                 continue
-
-            if resp.get("type") != "response":
+            if endpoint.instance_id in seen_instances:
+                # 同一次 Server 启动可能同时经 multicast 与 loopback 响应。
+                # One Server start may answer through both multicast and loopback.
                 continue
-            if resp.get("request_id") != request_id:
-                continue
-            pid = int(resp.get("pid", 0))
-            if pid and pid in seen_pids:
-                continue  # same editor answering on two interfaces — dedup
-            seen_pids.add(pid)
-
-            results.append(Endpoint(
-                pid=pid,
-                project=str(resp.get("project", "")),
-                project_path=str(resp.get("project_path", "")),
-                engine_version=str(resp.get("engine_version", "")),
-                tcp_bind=str(resp.get("tcp_bind", "127.0.0.1")),
-                tcp_port=int(resp.get("tcp_port", 0)),
-                token_fingerprint=str(resp.get("token_fingerprint", "")),
-            ))
+            seen_instances.add(endpoint.instance_id)
+            results.append(endpoint)
 
         return results
     finally:
@@ -184,9 +266,9 @@ def select(endpoints: List[Endpoint],
             "  2. The UnrealBridge plugin is installed in that project's "
             "Plugins/ folder AND enabled in the .uproject.\n"
             "  3. UDP discovery isn't being blocked locally — if everything "
-            "else is fine, pass --endpoint=127.0.0.1:<port>, "
-            "reading <port> from the editor log line "
-            "`LogUnrealBridge: Listening on 127.0.0.1:<port>`."
+            "else is fine, direct mode requires the complete --endpoint, "
+            "--instance-id, --expected-pid, and --expected-project-path tuple "
+            "printed by the Server startup log."
         )
 
     if project_filter and project_filter != "*":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,15 +32,17 @@ python .claude/skills/unreal-bridge/scripts/bridge.py exec-file script.py
 
 ### TCP Protocol
 Length-prefixed JSON over TCP on an OS-assigned port (default bind `127.0.0.1`, port auto-allocated at startup). Clients find the editor via the UDP multicast discovery service (see next section) — port 9876 is no longer hardcoded on the TCP data channel.
-- Request: `[4 bytes big-endian length][JSON: {"id":"...", "script":"...", "timeout":30, "token":"..." (optional)}]`
-- Response: `[4 bytes big-endian length][JSON: {"id":"...", "success":bool, "output":"...", "error":"..."}]`
+- Request: `[4 bytes big-endian length][JSON: {"id":"...", "command":"exact_exec", "expected":{"protocol_version":2,"instance_id":"...","pid":...,"project_path":"..."}, "request":{"script":"...","timeout":30}, "token":"..." (optional)}]`
+- Response: `[4 bytes big-endian length][JSON: {"id":"...", "success":bool, "output":"...", "error":"...", "protocol_version":2, "instance_id":"...", "pid":..., "project_path":"..."}]`
 - Token auth: required when the server binds non-loopback. The token is written to `<Project>/Saved/UnrealBridge/token.txt`; clients read it and add `"token":"<value>"` to every request. Constant-time compared on the server.
-- Special commands (handled inline on the worker thread, bypass the Python exec queue):
-  - `{"id":"...", "command":"ping"}` → `pong` (TCP-only liveness)
-  - `{"id":"...", "command":"gamethread_ping", "timeout":2.0}` → `alive`/`unresponsive` + `latency_ms` (GT liveness)
-  - `{"id":"...", "command":"debug_resume"}` → unsticks a paused BP breakpoint via `FKismetDebugUtilities::RequestAbortingExecution`
-  - `{"id":"...", "command":"modal_status"}` → structured active-Slate-modal snapshot (title, body, buttons, redacted inputs, checkboxes)
-  - `{"id":"...", "command":"modal_action", "snapshot":"...", "action":"..."}` → guarded click/input/checkbox action; rejects stale snapshots
+- Every request uses an `exact_*` command with frozen discovery identity. Payload fields live under `request`, so a legacy server cannot mistake `exact_exec` for an ordinary script request. The production dispatcher rejects missing/malformed identity, request objects, and unknown/legacy commands before any command body, work admission, or GameThread dispatch; the client rejects response identity drift. `project_path` is one wire-canonical string and must match discovery/startup output exactly on every OS.
+- Client response frames are bounded to `MAX_RESPONSE_FRAME_BYTES` (10 MiB), must be non-empty, valid UTF-8, and decode to a JSON object before identity fields are read.
+- Special exact commands (handled inline on the worker thread, bypass the Python exec queue):
+  - `exact_ping` → `pong` (TCP-only liveness)
+  - `exact_gamethread_ping` → `alive`/`unresponsive` + `latency_ms` (GT liveness)
+  - `exact_debug_resume` → unsticks a paused BP breakpoint via `FKismetDebugUtilities::RequestAbortingExecution`
+  - `exact_modal_status` → structured active-Slate-modal snapshot (title, body, buttons, redacted inputs, checkboxes)
+  - `exact_modal_action` → guarded click/input/checkbox action; rejects stale snapshots
 
 `bridge.py exec*` automatically calls `modal_status` after an exec timeout and
 adds `blocked_by_modal` plus the snapshot to its response. It never selects an
@@ -57,10 +59,10 @@ uses the same queued cancellation path, and drains tracked worker/GameThread clo
 module unload; each result/event therefore has exactly one terminal publisher.
 
 ### Discovery Protocol
-UDP discovery uses LAN multicast on `239.255.42.99:9876` plus a parallel local-loopback probe to `127.0.0.1:9876`. Both carry the same request id and responses are de-duplicated by editor PID. This preserves LAN discovery while avoiding dependence on Windows multicast loopback. Multiple editors can bind via `SO_REUSEADDR`.
-- Probe (client → group): `{"v":1, "type":"probe", "request_id":"<uuid>", "filter":{"project":"<name|path|*>"}}`
-- Response (server → probe source, unicast): `{"v":1, "type":"response", "request_id":"<uuid>", "pid":..., "project":"...", "project_path":"...", "engine_version":"...", "tcp_bind":"...", "tcp_port":..., "token_fingerprint":"<sha1(token)[:16]>"}`
-- Client loop: send the same probe to multicast + loopback → collect for `--discovery-timeout` ms (default 800) → de-duplicate by PID → filter by `--project=...` → connect TCP. Empty `token_fingerprint` means no token required.
+UDP discovery uses LAN multicast on `239.255.42.99:9876` plus a parallel local-loopback probe to `127.0.0.1:9876`. Both carry the same request id and responses are de-duplicated by Server-start UUID. This preserves LAN discovery while avoiding dependence on Windows multicast loopback. Multiple editors can bind via `SO_REUSEADDR`.
+- Probe (client → group): `{"v":2, "type":"probe", "request_id":"<uuid>", "filter":{"project":"<name|path|*>"}}`
+- Response (server → probe source, unicast): `{"v":2, "protocol_version":2, "type":"response", "request_id":"<uuid>", "instance_id":"<uuid>", "pid":..., "project":"...", "project_path":"...", "engine_version":"...", "tcp_bind":"...", "tcp_port":..., "token_fingerprint":"<sha1(token)[:16]>", "capabilities":["exact_exec",...]}`. The six exact commands are the minimum required capability set; unique forward-compatible extras are allowed.
+- Client loop: send the same probe to multicast + loopback → collect for `--discovery-timeout` ms (default 800) → discard each malformed/incomplete/legacy datagram without aborting collection → de-duplicate by instance UUID → filter by `--project=...` → freeze identity → connect TCP. A wildcard advertised bind resolves to that response's source IP. Empty `token_fingerprint` means no token required. Direct mode requires the inseparable `--endpoint`, `--instance-id`, `--expected-pid`, and `--expected-project-path` tuple, copied verbatim from discovery/startup output.
 
 ### Server configuration (CLI / env / editor ini)
 Priority CLI > env > `EditorPerProjectUserSettings.ini [UnrealBridge]` > default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ action automatically. The caller must read the dialog semantics and act with
 the returned `snapshot_id`; this prevents both blind confirmation and a stale
 action landing on a different dialog.
 
+Exec and modal GameThread work share a cancellable lifecycle. If the server-side
+deadline expires while work is still queued, the response reports `cancelled before execution`
+and a later ticker/task-graph consumer cannot run the body. If the GameThread already claimed
+the work, it is not safely retractable; the response reports `already started and outcome is unknown`
+instead of claiming a successful cancellation. Shutdown first closes a shared admission gate,
+uses the same queued cancellation path, and drains tracked worker/GameThread closures before
+module unload; each result/event therefore has exactly one terminal publisher.
+
 ### Discovery Protocol
 UDP discovery uses LAN multicast on `239.255.42.99:9876` plus a parallel local-loopback probe to `127.0.0.1:9876`. Both carry the same request id and responses are de-duplicated by editor PID. This preserves LAN discovery while avoiding dependence on Windows multicast loopback. Multiple editors can bind via `SO_REUSEADDR`.
 - Probe (client → group): `{"v":1, "type":"probe", "request_id":"<uuid>", "filter":{"project":"<name|path|*>"}}`

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeCancellableWorkTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeCancellableWorkTests.cpp
@@ -1,0 +1,292 @@
+#include "Misc/AutomationTest.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "UnrealBridgeCancellableWork.h"
+#include "UnrealBridgeServer.h"
+#include "SocketSubsystem.h"
+#include "Misc/ScopeExit.h"
+
+/**
+ * Automation 只读访问 Server lifecycle 计数，不改变生产行为。
+ * Automation-only read access to Server lifecycle counters; it does not change production behavior.
+ */
+class FUnrealBridgeServerTestAccessor
+{
+public:
+	static int32 GetActiveClientCount(const FUnrealBridgeServer& Server)
+	{
+		return Server.ActiveClients.GetValue();
+	}
+
+	static int32 GetTrackedWorkerCount(const FUnrealBridgeServer& Server)
+	{
+		return Server.ClientWorkerTasks.Num();
+	}
+
+	static bool EnqueueExec(
+		FUnrealBridgeServer& Server,
+		TFunction<void()>&& Body,
+		bool bCancelBeforeConsume,
+		const FString& RequestId)
+	{
+		return Server.EnqueueExecForTesting(MoveTemp(Body), bCancelBeforeConsume, RequestId);
+	}
+
+	static void TickExecQueue(FUnrealBridgeServer& Server)
+	{
+		Server.TickConsumeQueue(0.0f);
+	}
+};
+
+namespace UnrealBridgeCancellableWorkTests
+{
+	using FIntWork = TUnrealBridgeCancellableWork<int32>;
+
+	int32 StateValue(EUnrealBridgeWorkState State)
+	{
+		return static_cast<int32>(State);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeCancelledWorkSkipsLateConsumerTest,
+	"UnrealBridge.Server.CancellableWork.CancelledWorkSkipsLateConsumer",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeCancelledWorkSkipsLateConsumerTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeCancellableWorkTests;
+	(void)Parameters;
+
+	int32 SideEffectCount = 0;
+	TFunction<int32()> Body = [&SideEffectCount]()
+	{
+		++SideEffectCount;
+		return 42;
+	};
+	TSharedPtr<FIntWork, ESPMode::ThreadSafe> Work =
+		MakeShared<FIntWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	TestTrue(TEXT("queued cancellation wins"), Work->TryCancel(-7, ObservedState));
+	TestEqual(TEXT("cancel observes terminal state"), StateValue(ObservedState),
+		StateValue(EUnrealBridgeWorkState::Cancelled));
+	TestFalse(TEXT("late consumer cannot claim cancelled work"), Work->TryExecute());
+	TestEqual(TEXT("cancelled work has no late side effect"), SideEffectCount, 0);
+	TestEqual(TEXT("state remains cancelled"), StateValue(Work->GetState()),
+		StateValue(EUnrealBridgeWorkState::Cancelled));
+
+	TestTrue(TEXT("cancellation publishes one result"), Work->WaitFor(FTimespan::Zero()));
+	if (Work->WaitFor(FTimespan::Zero()))
+	{
+		TestEqual(TEXT("published cancellation result is stable"), Work->GetResult(), -7);
+	}
+
+	EUnrealBridgeWorkState SecondObservedState = EUnrealBridgeWorkState::Queued;
+	TestFalse(TEXT("terminal cancellation cannot publish twice"),
+		Work->TryCancel(-9, SecondObservedState));
+	TestEqual(TEXT("second cancellation observes first terminal state"),
+		StateValue(SecondObservedState), StateValue(EUnrealBridgeWorkState::Cancelled));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeRunningWorkCannotBeCancelledTest,
+	"UnrealBridge.Server.CancellableWork.RunningWorkCannotBeCancelled",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeRunningWorkCannotBeCancelledTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeCancellableWorkTests;
+	(void)Parameters;
+
+	TSharedPtr<FIntWork, ESPMode::ThreadSafe> Work;
+	bool bCancellationWon = true;
+	EUnrealBridgeWorkState StateSeenInsideBody = EUnrealBridgeWorkState::Queued;
+	TFunction<int32()> Body = [&Work, &bCancellationWon, &StateSeenInsideBody]()
+	{
+		// body 内的显式尝试稳定模拟 deadline 在 consumer claim 后到达。
+		// An explicit in-body attempt deterministically models a deadline arriving after consumer claim.
+		bCancellationWon = Work->TryCancel(-1, StateSeenInsideBody);
+		return 42;
+	};
+	Work = MakeShared<FIntWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+	TestTrue(TEXT("consumer claims and executes queued work"), Work->TryExecute());
+	TestFalse(TEXT("running work cannot be relabelled cancelled"), bCancellationWon);
+	TestEqual(TEXT("deadline observes running"), StateValue(StateSeenInsideBody),
+		StateValue(EUnrealBridgeWorkState::Running));
+	TestEqual(TEXT("successful body reaches completed"), StateValue(Work->GetState()),
+		StateValue(EUnrealBridgeWorkState::Completed));
+	TestTrue(TEXT("completed work publishes its result"), Work->WaitFor(FTimespan::Zero()));
+	if (Work->WaitFor(FTimespan::Zero()))
+	{
+		TestEqual(TEXT("completed result remains authoritative"), Work->GetResult(), 42);
+	}
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	TestFalse(TEXT("completed work cannot be cancelled"), Work->TryCancel(-2, ObservedState));
+	TestEqual(TEXT("post-completion cancellation observes completed"), StateValue(ObservedState),
+		StateValue(EUnrealBridgeWorkState::Completed));
+	TestFalse(TEXT("completed work cannot execute twice"), Work->TryExecute());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeAdmissionGateRejectsAfterCloseTest,
+	"UnrealBridge.Server.CancellableWork.AdmissionGateRejectsAfterClose",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeAdmissionGateRejectsAfterCloseTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	FUnrealBridgeWorkAdmissionGate Gate;
+	int32 AdmissionCount = 0;
+	TestFalse(TEXT("closed gate rejects initial work"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+
+	Gate.Open();
+	TestTrue(TEXT("open gate admits registration"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+	Gate.Close();
+	TestFalse(TEXT("closed shutdown gate rejects trailing work"), Gate.TryAdmit([&AdmissionCount]()
+	{
+		++AdmissionCount;
+	}));
+	TestEqual(TEXT("only pre-shutdown callback ran"), AdmissionCount, 1);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeCancelledBacklogDrainsBeforeLiveWorkTest,
+	"UnrealBridge.Server.CancellableWork.CancelledBacklogDrainsBeforeLiveWork",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeCancelledBacklogDrainsBeforeLiveWorkTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Server =
+		MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
+	if (!TestTrue(TEXT("test server starts for production ticker coverage"), Server->Start(0)))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		if (Server->IsRunning())
+		{
+			Server->Stop();
+		}
+	};
+
+	int32 CancelledSideEffects = 0;
+	int32 LiveSideEffects = 0;
+	for (int32 Index = 0; Index < 3; ++Index)
+	{
+		TFunction<void()> Body = [&CancelledSideEffects]()
+		{
+			++CancelledSideEffects;
+		};
+		TestTrue(TEXT("cancelled backlog item entered the production queue"),
+			FUnrealBridgeServerTestAccessor::EnqueueExec(
+				*Server, MoveTemp(Body), true, FString::Printf(TEXT("cancelled-%d"), Index)));
+	}
+
+	TFunction<void()> LiveBody = [&LiveSideEffects]()
+	{
+		++LiveSideEffects;
+	};
+	TestTrue(TEXT("live item entered behind cancelled tombstones"),
+		FUnrealBridgeServerTestAccessor::EnqueueExec(
+			*Server, MoveTemp(LiveBody), false, TEXT("live")));
+
+	FUnrealBridgeServerTestAccessor::TickExecQueue(*Server);
+	TestEqual(TEXT("cancelled production backlog produced no side effects"), CancelledSideEffects, 0);
+	TestEqual(TEXT("production ticker reached one live body in the same drain"), LiveSideEffects, 1);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeStopDrainsStragglingWorkerTest,
+	"UnrealBridge.Server.CancellableWork.StopDrainsStragglingWorker",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeStopDrainsStragglingWorkerTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Server =
+		MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
+	if (!TestTrue(TEXT("test server starts on an ephemeral port"), Server->Start(0)))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		if (Server->IsRunning())
+		{
+			Server->Stop();
+		}
+	};
+
+	ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+	if (!TestNotNull(TEXT("socket subsystem is available"), SocketSubsystem))
+	{
+		return false;
+	}
+	FSocket* ClientSocket = SocketSubsystem->CreateSocket(
+		NAME_Stream, TEXT("UnrealBridge shutdown automation client"), false);
+	if (!TestNotNull(TEXT("client socket was created"), ClientSocket))
+	{
+		return false;
+	}
+	ON_SCOPE_EXIT
+	{
+		ClientSocket->Close();
+		SocketSubsystem->DestroySocket(ClientSocket);
+	};
+
+	TSharedRef<FInternetAddr> Address = SocketSubsystem->CreateInternetAddr();
+	bool bValidAddress = false;
+	Address->SetIp(TEXT("127.0.0.1"), bValidAddress);
+	Address->SetPort(Server->GetBoundPort());
+	TestTrue(TEXT("loopback address is valid"), bValidAddress);
+	if (!TestTrue(TEXT("client connects to the test server"), ClientSocket->Connect(*Address)))
+	{
+		return false;
+	}
+
+	// 只发送 frame header，让真实 worker 阻塞在 payload recv；Stop 必须关 socket 并等待 graph event。
+	// Send only a frame header so the real worker blocks in payload recv; Stop must close it and wait for its graph event.
+	const uint8 Header[4] = { 0, 0, 0, 32 };
+	int32 BytesSent = 0;
+	TestTrue(TEXT("partial request header was sent"),
+		ClientSocket->Send(Header, static_cast<int32>(UE_ARRAY_COUNT(Header)), BytesSent));
+	TestEqual(TEXT("full frame header was sent"), BytesSent,
+		static_cast<int32>(UE_ARRAY_COUNT(Header)));
+
+	const double AcceptDeadline = FPlatformTime::Seconds() + 2.0;
+	while (FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server) == 0
+		&& FPlatformTime::Seconds() < AcceptDeadline)
+	{
+		FPlatformProcess::Sleep(0.001f);
+	}
+	TestEqual(TEXT("one straggling worker is tracked before shutdown"),
+		FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server), 1);
+
+	Server->Stop();
+	TestEqual(TEXT("Stop waits for worker closure completion"),
+		FUnrealBridgeServerTestAccessor::GetActiveClientCount(*Server), 0);
+	TestEqual(TEXT("Stop releases all tracked graph events"),
+		FUnrealBridgeServerTestAccessor::GetTrackedWorkerCount(*Server), 0);
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeEndpointIdentityTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeEndpointIdentityTests.cpp
@@ -1,0 +1,202 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "UnrealBridgeEndpointIdentity.h"
+#include "UnrealBridgeExactRequestDispatcher.h"
+#include "UnrealBridgeProtocol.h"
+#include <limits>
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeEndpointIdentityPreconditionTest,
+	"UnrealBridge.Server.EndpointIdentity.Preconditions",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeEndpointIdentityPreconditionTest::RunTest(const FString& Parameters)
+{
+	FUnrealBridgeEndpointIdentity Identity;
+	Identity.InstanceId = TEXT("11111111-2222-3333-4444-555555555555");
+	Identity.ProcessId = 4242;
+	Identity.ProjectPath = TEXT("C:/Projects/TestProject/TestProject.uproject");
+
+	auto BuildWireRequest = [&Identity](
+		const FString& Command,
+		double Protocol,
+		double Pid,
+		const FString& ProjectPath)
+	{
+		TSharedPtr<FJsonObject> Expected = MakeShared<FJsonObject>();
+		Expected->SetNumberField(UnrealBridgeProtocol::ProtocolVersionField, Protocol);
+		Expected->SetStringField(UnrealBridgeProtocol::InstanceIdField, Identity.InstanceId);
+		Expected->SetNumberField(UnrealBridgeProtocol::ProcessIdField, Pid);
+		Expected->SetStringField(UnrealBridgeProtocol::ProjectPathField, ProjectPath);
+
+		TSharedPtr<FJsonObject> Request = MakeShared<FJsonObject>();
+		Request->SetStringField(UnrealBridgeProtocol::CommandField, Command);
+		Request->SetObjectField(UnrealBridgeProtocol::ExpectedField, Expected);
+		Request->SetObjectField(UnrealBridgeProtocol::RequestField, MakeShared<FJsonObject>());
+		return Request;
+	};
+
+	auto BuildValidRequest = [&BuildWireRequest, &Identity](const FString& Command)
+	{
+		return BuildWireRequest(
+			Command,
+			FUnrealBridgeEndpointIdentity::ProtocolVersion,
+			Identity.ProcessId,
+			Identity.ProjectPath);
+	};
+
+	struct FCommandCase
+	{
+		const TCHAR* WireCommand;
+		EUnrealBridgeExactCommand ExpectedCommand;
+	};
+	const FCommandCase CommandCases[] = {
+		{UnrealBridgeProtocol::ExactExec, EUnrealBridgeExactCommand::Exec},
+		{UnrealBridgeProtocol::ExactPing, EUnrealBridgeExactCommand::Ping},
+		{UnrealBridgeProtocol::ExactGameThreadPing, EUnrealBridgeExactCommand::GameThreadPing},
+		{UnrealBridgeProtocol::ExactDebugResume, EUnrealBridgeExactCommand::DebugResume},
+		{UnrealBridgeProtocol::ExactModalStatus, EUnrealBridgeExactCommand::ModalStatus},
+		{UnrealBridgeProtocol::ExactModalAction, EUnrealBridgeExactCommand::ModalAction},
+	};
+
+	for (const FCommandCase& CommandCase : CommandCases)
+	{
+		int32 AdmissionCount = 0;
+		EUnrealBridgeExactCommand ObservedCommand = EUnrealBridgeExactCommand::Exec;
+		FString Code;
+		FString Error;
+		const bool bAccepted = FUnrealBridgeExactRequestDispatcher::TryDispatch(
+			BuildValidRequest(CommandCase.WireCommand),
+			Identity,
+			[&AdmissionCount, &ObservedCommand](const FUnrealBridgeAcceptedRequest& Accepted)
+			{
+				++AdmissionCount;
+				ObservedCommand = Accepted.Command;
+			},
+			Code,
+			Error);
+		TestTrue(FString::Printf(TEXT("%s is admitted"), CommandCase.WireCommand), bAccepted);
+		TestEqual(FString::Printf(TEXT("%s admits exactly one body"), CommandCase.WireCommand), AdmissionCount, 1);
+		TestEqual(FString::Printf(TEXT("%s maps to its typed command"), CommandCase.WireCommand),
+			static_cast<uint8>(ObservedCommand), static_cast<uint8>(CommandCase.ExpectedCommand));
+	}
+
+	auto ExpectRejected = [this, &Identity](
+		const FString& Label,
+		const TSharedPtr<FJsonObject>& Request,
+		const FString& ExpectedCode)
+	{
+		int32 AdmissionCount = 0;
+		FString Code;
+		FString Error;
+		const bool bAccepted = FUnrealBridgeExactRequestDispatcher::TryDispatch(
+			Request,
+			Identity,
+			[&AdmissionCount](const FUnrealBridgeAcceptedRequest&)
+			{
+				++AdmissionCount;
+			},
+			Code,
+			Error);
+		TestFalse(Label + TEXT(" is rejected"), bAccepted);
+		TestEqual(Label + TEXT(" does not enter the body/admission callback"), AdmissionCount, 0);
+		TestEqual(Label + TEXT(" has a structured error code"), Code, ExpectedCode);
+	};
+
+	ExpectRejected(TEXT("legacy command"), BuildValidRequest(TEXT("ping")), TEXT("exact_command_required"));
+	ExpectRejected(TEXT("unknown exact alias"), BuildValidRequest(TEXT("exact_exec_alias")), TEXT("unsupported_command"));
+	TSharedPtr<FJsonObject> MissingCommand = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MissingCommand->RemoveField(UnrealBridgeProtocol::CommandField);
+	ExpectRejected(TEXT("missing command"), MissingCommand, TEXT("exact_command_required"));
+
+	TSharedPtr<FJsonObject> MissingExpected = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MissingExpected->RemoveField(UnrealBridgeProtocol::ExpectedField);
+	ExpectRejected(TEXT("missing expected"), MissingExpected, TEXT("identity_required"));
+	TSharedPtr<FJsonObject> MalformedExpected = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedExpected->SetStringField(UnrealBridgeProtocol::ExpectedField, TEXT("not-an-object"));
+	ExpectRejected(TEXT("non-object expected"), MalformedExpected, TEXT("identity_required"));
+
+	TSharedPtr<FJsonObject> MalformedProtocolType = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedProtocolType->GetObjectField(UnrealBridgeProtocol::ExpectedField)->SetStringField(
+		UnrealBridgeProtocol::ProtocolVersionField, TEXT("2"));
+	ExpectRejected(TEXT("non-number protocol"), MalformedProtocolType, TEXT("protocol_mismatch"));
+	TSharedPtr<FJsonObject> MalformedPidType = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedPidType->GetObjectField(UnrealBridgeProtocol::ExpectedField)->SetStringField(
+		UnrealBridgeProtocol::ProcessIdField, TEXT("4242"));
+	ExpectRejected(TEXT("non-number pid"), MalformedPidType, TEXT("pid_mismatch"));
+	TSharedPtr<FJsonObject> MalformedInstanceType = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedInstanceType->GetObjectField(UnrealBridgeProtocol::ExpectedField)->SetNumberField(
+		UnrealBridgeProtocol::InstanceIdField, 1.0);
+	ExpectRejected(TEXT("non-string instance"), MalformedInstanceType, TEXT("identity_required"));
+	TSharedPtr<FJsonObject> MalformedPathType = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedPathType->GetObjectField(UnrealBridgeProtocol::ExpectedField)->SetNumberField(
+		UnrealBridgeProtocol::ProjectPathField, 1.0);
+	ExpectRejected(TEXT("non-string project path"), MalformedPathType, TEXT("identity_required"));
+
+	TSharedPtr<FJsonObject> MissingPayload = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MissingPayload->RemoveField(UnrealBridgeProtocol::RequestField);
+	ExpectRejected(TEXT("missing request"), MissingPayload, TEXT("invalid_request"));
+	TSharedPtr<FJsonObject> MalformedPayload = BuildValidRequest(UnrealBridgeProtocol::ExactPing);
+	MalformedPayload->SetStringField(UnrealBridgeProtocol::RequestField, TEXT("not-an-object"));
+	ExpectRejected(TEXT("non-object request"), MalformedPayload, TEXT("invalid_request"));
+
+	TSharedPtr<FJsonObject> WrongInstance = BuildValidRequest(UnrealBridgeProtocol::ExactExec);
+	WrongInstance->GetObjectField(UnrealBridgeProtocol::ExpectedField)->SetStringField(
+		UnrealBridgeProtocol::InstanceIdField, TEXT("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+	ExpectRejected(TEXT("stale instance"), WrongInstance, TEXT("instance_mismatch"));
+
+	ExpectRejected(
+		TEXT("project case mismatch"),
+		BuildWireRequest(UnrealBridgeProtocol::ExactExec, FUnrealBridgeEndpointIdentity::ProtocolVersion,
+			Identity.ProcessId, TEXT("c:/Projects/TestProject/TestProject.uproject")),
+		TEXT("project_mismatch"));
+	ExpectRejected(
+		TEXT("project separator mismatch"),
+		BuildWireRequest(UnrealBridgeProtocol::ExactExec, FUnrealBridgeEndpointIdentity::ProtocolVersion,
+			Identity.ProcessId, TEXT("C:\\Projects\\TestProject\\TestProject.uproject")),
+		TEXT("project_mismatch"));
+
+	struct FNumberCase
+	{
+		const TCHAR* Label;
+		double Value;
+	};
+	const FNumberCase InvalidProtocols[] = {
+		{TEXT("fractional protocol"), 2.4},
+		{TEXT("zero protocol"), 0.0},
+		{TEXT("negative protocol"), -2.0},
+		{TEXT("non-finite protocol"), std::numeric_limits<double>::quiet_NaN()},
+		{TEXT("infinite protocol"), std::numeric_limits<double>::infinity()},
+		{TEXT("out-of-range protocol"), static_cast<double>(TNumericLimits<int32>::Max()) + 1.0},
+	};
+	for (const FNumberCase& NumberCase : InvalidProtocols)
+	{
+		ExpectRejected(
+			NumberCase.Label,
+			BuildWireRequest(UnrealBridgeProtocol::ExactPing, NumberCase.Value, Identity.ProcessId, Identity.ProjectPath),
+			TEXT("protocol_mismatch"));
+	}
+
+	const FNumberCase InvalidPids[] = {
+		{TEXT("fractional pid"), 4242.4},
+		{TEXT("zero pid"), 0.0},
+		{TEXT("negative pid"), -4242.0},
+		{TEXT("non-finite pid"), std::numeric_limits<double>::quiet_NaN()},
+		{TEXT("infinite pid"), std::numeric_limits<double>::infinity()},
+		{TEXT("out-of-range pid"), static_cast<double>(TNumericLimits<int32>::Max()) + 1.0},
+	};
+	for (const FNumberCase& NumberCase : InvalidPids)
+	{
+		ExpectRejected(
+			NumberCase.Label,
+			BuildWireRequest(UnrealBridgeProtocol::ExactPing,
+				FUnrealBridgeEndpointIdentity::ProtocolVersion, NumberCase.Value, Identity.ProjectPath),
+			TEXT("pid_mismatch"));
+	}
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeCancellableWork.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeCancellableWork.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/Event.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/ScopeLock.h"
+
+/**
+ * 可取消 work item 的生命周期；只有 queued 可以进入 running 或 cancelled。
+ * Lifecycle for cancellable work; only queued work may become running or cancelled.
+ */
+enum class EUnrealBridgeWorkState : uint8
+{
+	Queued,
+	Running,
+	Cancelled,
+	Completed,
+};
+
+/**
+ * 串行化 Server shutdown 与新 work 的注册；Close 返回后任何 callback 都不能再进入。
+ * Serializes Server shutdown against new work registration; no callback can enter after Close returns.
+ */
+class FUnrealBridgeWorkAdmissionGate final
+{
+public:
+	/** 开放新一轮 Server admission。 / Open admission for a new Server run. */
+	void Open()
+	{
+		FScopeLock Lock(&GateLock);
+		bOpen = true;
+	}
+
+	/** 关闭 admission，并等待已经进入的注册 callback 离开。 / Close admission and wait for entered callbacks to leave. */
+	void Close()
+	{
+		FScopeLock Lock(&GateLock);
+		bOpen = false;
+	}
+
+	/**
+	 * 只在 gate 开放时、持锁执行注册 callback，使 enqueue/task registration 与 Close 原子排序。
+	 * Run registration under the gate lock only while open, atomically ordering enqueue/task registration with Close.
+	 */
+	template <typename CallbackType>
+	bool TryAdmit(CallbackType&& Callback)
+	{
+		FScopeLock Lock(&GateLock);
+		if (!bOpen)
+		{
+			return false;
+		}
+		Forward<CallbackType>(Callback)();
+		return true;
+	}
+
+	/** 返回当前 admission 状态。 / Return the current admission state. */
+	bool IsOpen() const
+	{
+		FScopeLock Lock(&GateLock);
+		return bOpen;
+	}
+
+private:
+	mutable FCriticalSection GateLock;
+	bool bOpen = false;
+};
+
+/**
+ * 在 worker 与 GameThread 之间唯一拥有 work 状态、result 和 completion event。
+ * Sole owner of work state, result, and completion event across worker/GameThread.
+ *
+ * 同一把锁使状态转换与 result 发布成为不可分割的观测边界；body 在锁外执行，
+ * 因此 timeout 可以观察 running 并明确报告结果未知，而不会把已开始的动作误报为已取消。
+ * One lock makes state transition and result publication a single observation boundary. The body
+ * runs outside the lock so a timeout can observe running and report an unknown outcome without
+ * falsely claiming that already-started work was cancelled.
+ */
+template <typename TResult>
+class TUnrealBridgeCancellableWork final
+{
+public:
+	explicit TUnrealBridgeCancellableWork(TFunction<TResult()>&& InBody)
+		: Body(MoveTemp(InBody))
+		, CompletionEvent(FPlatformProcess::GetSynchEventFromPool(true))
+	{
+		check(CompletionEvent != nullptr);
+	}
+
+	~TUnrealBridgeCancellableWork()
+	{
+		if (CompletionEvent != nullptr)
+		{
+			FPlatformProcess::ReturnSynchEventToPool(CompletionEvent);
+			CompletionEvent = nullptr;
+		}
+	}
+
+	TUnrealBridgeCancellableWork(const TUnrealBridgeCancellableWork&) = delete;
+	TUnrealBridgeCancellableWork& operator=(const TUnrealBridgeCancellableWork&) = delete;
+
+	/**
+	 * 仅当状态仍为 queued 时执行 body；晚到的 consumer 会观察 cancelled 并跳过。
+	 * Execute only while queued; a late consumer observes cancelled and skips the body.
+	 */
+	bool TryExecute()
+	{
+		{
+			FScopeLock Lock(&StateLock);
+			if (State != EUnrealBridgeWorkState::Queued)
+			{
+				return false;
+			}
+			State = EUnrealBridgeWorkState::Running;
+		}
+
+		TResult WorkResult = Body();
+
+		{
+			FScopeLock Lock(&StateLock);
+			check(State == EUnrealBridgeWorkState::Running);
+			Result.Emplace(MoveTemp(WorkResult));
+			State = EUnrealBridgeWorkState::Completed;
+		}
+		CompletionEvent->Trigger();
+		return true;
+	}
+
+	/**
+	 * 仅取消尚未开始的 queued work，并以调用方提供的结果完成等待。
+	 * Cancel only queued work and complete the wait with the caller-supplied result.
+	 *
+	 * @param CancellationResult 取消成功时发布的结果。 / Result published when cancellation wins.
+	 * @param OutObservedState 返回取消尝试结束时的权威状态。 / Authoritative state observed by the attempt.
+	 * @return true 表示 body 永远不会执行；false 表示已开始或已终止。 / True means the body can never execute.
+	 */
+	bool TryCancel(TResult&& CancellationResult, EUnrealBridgeWorkState& OutObservedState)
+	{
+		{
+			FScopeLock Lock(&StateLock);
+			if (State != EUnrealBridgeWorkState::Queued)
+			{
+				OutObservedState = State;
+				return false;
+			}
+
+			Result.Emplace(MoveTemp(CancellationResult));
+			State = EUnrealBridgeWorkState::Cancelled;
+			OutObservedState = State;
+		}
+		CompletionEvent->Trigger();
+		return true;
+	}
+
+	/** 等待 terminal result，返回 false 表示 deadline 前未完成。 / Wait for a terminal result; false means the deadline elapsed. */
+	bool WaitFor(const FTimespan& Timeout) const
+	{
+		return CompletionEvent->Wait(Timeout);
+	}
+
+	/** 返回 terminal result 的副本；调用前必须已经完成或取消。 / Return a copy of the terminal result; wait first. */
+	TResult GetResult() const
+	{
+		FScopeLock Lock(&StateLock);
+		check(Result.IsSet());
+		return Result.GetValue();
+	}
+
+	/** 返回当前权威状态。 / Return the current authoritative state. */
+	EUnrealBridgeWorkState GetState() const
+	{
+		FScopeLock Lock(&StateLock);
+		return State;
+	}
+
+private:
+	TFunction<TResult()> Body;
+	mutable FCriticalSection StateLock;
+	TOptional<TResult> Result;
+	EUnrealBridgeWorkState State = EUnrealBridgeWorkState::Queued;
+	FEvent* CompletionEvent = nullptr;
+};

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeDiscovery.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeDiscovery.cpp
@@ -1,4 +1,5 @@
 #include "UnrealBridgeDiscovery.h"
+#include "UnrealBridgeProtocol.h"
 
 #include "Common/UdpSocketBuilder.h"
 #include "Dom/JsonObject.h"
@@ -220,7 +221,9 @@ void FBridgeDiscoveryService::HandleDatagram(const uint8* Bytes, int32 Length, c
 	}
 
 	double Version = 0.0;
-	if (!Root->TryGetNumberField(TEXT("v"), Version) || FMath::RoundToInt(Version) != 1)
+	if (!Root->TryGetNumberField(TEXT("v"), Version)
+		|| !FMath::IsFinite(Version)
+		|| Version != static_cast<double>(Config.ProtocolVersion))
 	{
 		return;
 	}
@@ -272,16 +275,24 @@ bool FBridgeDiscoveryService::FilterMatchesUs(const FString& Filter) const
 FString FBridgeDiscoveryService::BuildResponseJson(const FString& RequestId) const
 {
 	const TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
-	Root->SetNumberField(TEXT("v"), 1);
+	Root->SetNumberField(TEXT("v"), Config.ProtocolVersion);
+	Root->SetNumberField(TEXT("protocol_version"), Config.ProtocolVersion);
 	Root->SetStringField(TEXT("type"), TEXT("response"));
 	Root->SetStringField(TEXT("request_id"), RequestId);
-	Root->SetNumberField(TEXT("pid"), (int32)FPlatformProcess::GetCurrentProcessId());
+	Root->SetStringField(TEXT("instance_id"), Config.InstanceId);
+	Root->SetNumberField(TEXT("pid"), Config.ProcessId);
 	Root->SetStringField(TEXT("project"), Config.ProjectName);
 	Root->SetStringField(TEXT("project_path"), Config.ProjectPath);
 	Root->SetStringField(TEXT("engine_version"), Config.EngineVersion);
 	Root->SetStringField(TEXT("tcp_bind"), Config.TcpBindAddress);
 	Root->SetNumberField(TEXT("tcp_port"), CurrentTcpPort.GetValue());
 	Root->SetStringField(TEXT("token_fingerprint"), Config.TokenFingerprint);
+	TArray<TSharedPtr<FJsonValue>> Capabilities;
+	for (const TCHAR* Capability : UnrealBridgeProtocol::ExactCapabilities)
+	{
+		Capabilities.Add(MakeShared<FJsonValueString>(Capability));
+	}
+	Root->SetArrayField(TEXT("capabilities"), MoveTemp(Capabilities));
 
 	FString Out;
 	const TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeDiscovery.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeDiscovery.h
@@ -25,15 +25,20 @@ class FJsonObject;
  * Protocol:
  *
  *   probe  (client → group):
- *     {"v":1, "type":"probe", "request_id":"<uuid>",
+ *     {"v":2, "type":"probe", "request_id":"<uuid>",
  *      "filter": {"project": "<name|path|*>"}}
  *
  *   response (server → probe source):
- *     {"v":1, "type":"response", "request_id":"<uuid>",
- *      "pid": 1234, "project": "MyGame", "project_path": "C:/.../MyGame.uproject",
+ *     {"v":2, "protocol_version":2, "type":"response", "request_id":"<uuid>",
+ *      "instance_id":"<uuid>", "pid":1234,
+ *      "project":"MyGame", "project_path":"C:/.../MyGame.uproject",
  *      "engine_version": "5.7.0",
  *      "tcp_bind": "127.0.0.1", "tcp_port": 54321,
- *      "token_fingerprint": "a1b2c3d4e5f60718"}    // "" when no token
+ *      "token_fingerprint": "a1b2c3d4e5f60718",
+ *      "capabilities": ["exact_exec", ...]}    // minimum required set
+ *
+ * 通配 bind 由客户端解析为该 datagram 的响应源 IP；Server 不伪造 loopback endpoint。
+ * Clients resolve wildcard binds to the datagram source IP; the Server does not advertise a fake loopback endpoint.
  *
  * The TCP port is reported live from the running server — when the listener
  * is still negotiating port 0 at startup, `SetTcpPort` is used to hand the
@@ -52,9 +57,14 @@ public:
 		FString TcpBindAddress = TEXT("127.0.0.1");
 		int32 TcpPort = 0;
 
-		/** Project display name + .uproject path that filters match against. */
+		/** 工程显示名与唯一 wire-canonical .uproject 路径；客户端逐字冻结后者。 / Project display name and one wire-canonical .uproject path frozen verbatim by clients. */
 		FString ProjectName;
 		FString ProjectPath;
+
+		/** 本次 Server 启动的 exact identity。 / Exact identity for this Server start. */
+		int32 ProtocolVersion = 0;
+		FString InstanceId;
+		int32 ProcessId = 0;
 
 		/** Engine version string (e.g. "5.7.0"). */
 		FString EngineVersion;

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeEndpointIdentity.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeEndpointIdentity.cpp
@@ -1,0 +1,131 @@
+#include "UnrealBridgeEndpointIdentity.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/App.h"
+#include "Misc/Guid.h"
+#include "Misc/Paths.h"
+
+namespace
+{
+	/** JSON number 必须是有限、正数、int32 范围内的整数，并精确等于权威值。 / JSON numbers must be finite positive int32 integers exactly equal to the authority. */
+	bool IsExactPositiveInt32(double Value, int32 Authority)
+	{
+		return Authority > 0
+			&& FMath::IsFinite(Value)
+			&& Value >= 1.0
+			&& Value <= static_cast<double>(TNumericLimits<int32>::Max())
+			&& Value == static_cast<double>(static_cast<int32>(Value))
+			&& static_cast<int32>(Value) == Authority;
+	}
+}
+
+FUnrealBridgeEndpointIdentity FUnrealBridgeEndpointIdentity::Create()
+{
+	FUnrealBridgeEndpointIdentity Identity;
+	Identity.InstanceId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphensLower);
+	Identity.ProcessId = static_cast<int32>(FPlatformProcess::GetCurrentProcessId());
+	Identity.ProjectPath = NormalizeProjectPath(FPaths::Combine(
+		FPaths::ProjectDir(), FString::Printf(TEXT("%s.uproject"), FApp::GetProjectName())));
+	return Identity;
+}
+
+FString FUnrealBridgeEndpointIdentity::NormalizeProjectPath(FString Path)
+{
+	Path = FPaths::ConvertRelativePathToFull(Path);
+	FPaths::NormalizeFilename(Path);
+	FPaths::CollapseRelativeDirectories(Path);
+	return Path;
+}
+
+void FUnrealBridgeEndpointIdentity::AppendToResponse(const TSharedRef<FJsonObject>& Response) const
+{
+	Response->SetNumberField(UnrealBridgeProtocol::ProtocolVersionField, ProtocolVersion);
+	Response->SetStringField(UnrealBridgeProtocol::InstanceIdField, InstanceId);
+	Response->SetNumberField(UnrealBridgeProtocol::ProcessIdField, ProcessId);
+	Response->SetStringField(UnrealBridgeProtocol::ProjectPathField, ProjectPath);
+}
+
+bool FUnrealBridgeEndpointIdentity::ValidateRequest(
+	const TSharedPtr<FJsonObject>& Request,
+	FString& OutErrorCode,
+	FString& OutError) const
+{
+	const TSharedPtr<FJsonObject>* ExpectedPtr = nullptr;
+	if (!Request.IsValid()
+		|| !Request->TryGetObjectField(UnrealBridgeProtocol::ExpectedField, ExpectedPtr)
+		|| ExpectedPtr == nullptr
+		|| !ExpectedPtr->IsValid())
+	{
+		OutErrorCode = TEXT("identity_required");
+		OutError = TEXT("missing object field 'expected'; exact endpoint identity is required");
+		return false;
+	}
+
+	const TSharedPtr<FJsonObject>& Expected = *ExpectedPtr;
+
+	// UE 的 typed getter 会转换某些 JSON 类型；identity precondition 必须先验证原始 wire 类型再读取值。
+	// UE typed getters coerce some JSON types; identity preconditions must validate the raw wire type before reading values.
+	const TSharedPtr<FJsonValue>* ProtocolValue = Expected->Values.Find(UnrealBridgeProtocol::ProtocolVersionField);
+	if (ProtocolValue == nullptr
+		|| !ProtocolValue->IsValid()
+		|| (*ProtocolValue)->Type != EJson::Number
+		|| !IsExactPositiveInt32((*ProtocolValue)->AsNumber(), ProtocolVersion))
+	{
+		OutErrorCode = TEXT("protocol_mismatch");
+		OutError = FString::Printf(TEXT("expected protocol_version %d as a JSON number"), ProtocolVersion);
+		return false;
+	}
+
+	const TSharedPtr<FJsonValue>* InstanceValue = Expected->Values.Find(UnrealBridgeProtocol::InstanceIdField);
+	if (InstanceValue == nullptr
+		|| !InstanceValue->IsValid()
+		|| (*InstanceValue)->Type != EJson::String
+		|| (*InstanceValue)->AsString().IsEmpty())
+	{
+		OutErrorCode = TEXT("identity_required");
+		OutError = TEXT("missing or non-string expected.instance_id");
+		return false;
+	}
+	const FString ExpectedInstance = (*InstanceValue)->AsString();
+	if (!ExpectedInstance.Equals(InstanceId, ESearchCase::CaseSensitive))
+	{
+		OutErrorCode = TEXT("instance_mismatch");
+		OutError = TEXT("expected instance_id does not exactly match this Server start");
+		return false;
+	}
+
+	const TSharedPtr<FJsonValue>* PidValue = Expected->Values.Find(UnrealBridgeProtocol::ProcessIdField);
+	if (PidValue == nullptr
+		|| !PidValue->IsValid()
+		|| (*PidValue)->Type != EJson::Number
+		|| !IsExactPositiveInt32((*PidValue)->AsNumber(), ProcessId))
+	{
+		OutErrorCode = TEXT("pid_mismatch");
+		OutError = TEXT("expected pid must be an exact JSON integer matching this Server process");
+		return false;
+	}
+
+	const TSharedPtr<FJsonValue>* ProjectPathValue = Expected->Values.Find(UnrealBridgeProtocol::ProjectPathField);
+	if (ProjectPathValue == nullptr
+		|| !ProjectPathValue->IsValid()
+		|| (*ProjectPathValue)->Type != EJson::String
+		|| (*ProjectPathValue)->AsString().IsEmpty())
+	{
+		OutErrorCode = TEXT("identity_required");
+		OutError = TEXT("missing or non-string expected.project_path");
+		return false;
+	}
+	const FString ExpectedProjectPath = (*ProjectPathValue)->AsString();
+	// project_path 是 discovery/startup 输出的 wire identity；所有平台都必须逐字符、区分大小写匹配。
+	// project_path is the discovery/startup wire identity; every platform requires character-exact, case-sensitive equality.
+	if (!ExpectedProjectPath.Equals(ProjectPath, ESearchCase::CaseSensitive))
+	{
+		OutErrorCode = TEXT("project_mismatch");
+		OutError = TEXT("expected project_path must exactly match the discovery or startup value");
+		return false;
+	}
+
+	return true;
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeEndpointIdentity.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeEndpointIdentity.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UnrealBridgeProtocol.h"
+
+class FJsonObject;
+
+/**
+ * 端点身份是一次 Server 启动的不可复用事实源；discovery、TCP 前置条件与响应必须共享它。
+ * Endpoint identity is the non-reusable source of truth for one Server start; discovery, TCP preconditions, and responses share it.
+ */
+struct FUnrealBridgeEndpointIdentity
+{
+	static constexpr int32 ProtocolVersion = UnrealBridgeProtocol::Version;
+
+	FString InstanceId;
+	FString ProjectPath;
+	int32 ProcessId = 0;
+
+	/** 为当前进程的一次 Server 启动创建新身份。 / Create a fresh identity for one Server start in this process. */
+	static FUnrealBridgeEndpointIdentity Create();
+
+	/** 将权威身份写入所有 TCP 响应。 / Append the authoritative identity to every TCP response. */
+	void AppendToResponse(const TSharedRef<FJsonObject>& Response) const;
+
+	/**
+	 * 验证 expected identity；生产 dispatcher 保证在任何 command body 或 work admission 前调用。
+	 * Validate expected identity; the production dispatcher calls it before any command body or work admission.
+	 */
+	bool ValidateRequest(const TSharedPtr<FJsonObject>& Request, FString& OutErrorCode, FString& OutError) const;
+
+	/** 只生成 Server 的 wire-canonical 启动路径；客户端必须逐字复制结果。 / Generate the Server's wire-canonical startup path; clients must copy the result verbatim. */
+	static FString NormalizeProjectPath(FString Path);
+};

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeExactRequestDispatcher.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeExactRequestDispatcher.cpp
@@ -1,0 +1,91 @@
+#include "UnrealBridgeExactRequestDispatcher.h"
+
+#include "Dom/JsonObject.h"
+#include "UnrealBridgeEndpointIdentity.h"
+#include "UnrealBridgeProtocol.h"
+
+namespace
+{
+	bool TryMapCommand(const FString& WireCommand, EUnrealBridgeExactCommand& OutCommand)
+	{
+		if (WireCommand == UnrealBridgeProtocol::ExactExec)
+		{
+			OutCommand = EUnrealBridgeExactCommand::Exec;
+		}
+		else if (WireCommand == UnrealBridgeProtocol::ExactPing)
+		{
+			OutCommand = EUnrealBridgeExactCommand::Ping;
+		}
+		else if (WireCommand == UnrealBridgeProtocol::ExactGameThreadPing)
+		{
+			OutCommand = EUnrealBridgeExactCommand::GameThreadPing;
+		}
+		else if (WireCommand == UnrealBridgeProtocol::ExactDebugResume)
+		{
+			OutCommand = EUnrealBridgeExactCommand::DebugResume;
+		}
+		else if (WireCommand == UnrealBridgeProtocol::ExactModalStatus)
+		{
+			OutCommand = EUnrealBridgeExactCommand::ModalStatus;
+		}
+		else if (WireCommand == UnrealBridgeProtocol::ExactModalAction)
+		{
+			OutCommand = EUnrealBridgeExactCommand::ModalAction;
+		}
+		else
+		{
+			return false;
+		}
+		return true;
+	}
+}
+
+bool FUnrealBridgeExactRequestDispatcher::TryDispatch(
+	const TSharedPtr<FJsonObject>& WireRequest,
+	const FUnrealBridgeEndpointIdentity& Identity,
+	TFunctionRef<void(const FUnrealBridgeAcceptedRequest&)> OnAccepted,
+	FString& OutErrorCode,
+	FString& OutError)
+{
+	OutErrorCode.Reset();
+	OutError.Reset();
+
+	FString WireCommand;
+	if (!WireRequest.IsValid()
+		|| !WireRequest->TryGetStringField(UnrealBridgeProtocol::CommandField, WireCommand)
+		|| !WireCommand.StartsWith(UnrealBridgeProtocol::ExactPrefix, ESearchCase::CaseSensitive))
+	{
+		OutErrorCode = TEXT("exact_command_required");
+		OutError = TEXT("legacy or unknown wire form rejected; use an exact_* command with expected identity");
+		return false;
+	}
+
+	if (!Identity.ValidateRequest(WireRequest, OutErrorCode, OutError))
+	{
+		return false;
+	}
+
+	const TSharedPtr<FJsonObject>* PayloadPtr = nullptr;
+	if (!WireRequest->TryGetObjectField(UnrealBridgeProtocol::RequestField, PayloadPtr)
+		|| PayloadPtr == nullptr
+		|| !PayloadPtr->IsValid())
+	{
+		OutErrorCode = TEXT("invalid_request");
+		OutError = TEXT("missing or non-object field 'request'");
+		return false;
+	}
+
+	EUnrealBridgeExactCommand Command = EUnrealBridgeExactCommand::Exec;
+	if (!TryMapCommand(WireCommand, Command))
+	{
+		OutErrorCode = TEXT("unsupported_command");
+		OutError = FString::Printf(TEXT("unsupported exact command '%s'"), *WireCommand);
+		return false;
+	}
+
+	FUnrealBridgeAcceptedRequest Accepted;
+	Accepted.Command = Command;
+	Accepted.Payload = *PayloadPtr;
+	OnAccepted(Accepted);
+	return true;
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeExactRequestDispatcher.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeExactRequestDispatcher.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Templates/Function.h"
+
+class FJsonObject;
+struct FUnrealBridgeEndpointIdentity;
+
+/**
+ * exact wire 可进入的六种命令；未知别名不映射为 exec。
+ * Six commands admitted by the exact wire; unknown aliases never map to exec.
+ */
+enum class EUnrealBridgeExactCommand : uint8
+{
+	Exec,
+	Ping,
+	GameThreadPing,
+	DebugResume,
+	ModalStatus,
+	ModalAction,
+};
+
+/**
+ * 已通过 wire、identity、payload 与命令映射验证的请求。
+ * Request that passed wire, identity, payload, and command mapping validation.
+ */
+struct FUnrealBridgeAcceptedRequest
+{
+	EUnrealBridgeExactCommand Command = EUnrealBridgeExactCommand::Exec;
+	TSharedPtr<FJsonObject> Payload;
+};
+
+/**
+ * 生产请求的唯一前置调度门；只有全部前置条件通过才调用 admission callback。
+ * Sole pre-dispatch gate for production requests; invokes the admission callback only after every precondition passes.
+ */
+class FUnrealBridgeExactRequestDispatcher final
+{
+public:
+	/**
+	 * 验证并准入一个 exact request；拒绝时 callback 保证不执行。
+	 * Validate and admit one exact request; the callback is guaranteed not to run on rejection.
+	 */
+	static bool TryDispatch(
+		const TSharedPtr<FJsonObject>& WireRequest,
+		const FUnrealBridgeEndpointIdentity& Identity,
+		TFunctionRef<void(const FUnrealBridgeAcceptedRequest&)> OnAccepted,
+		FString& OutErrorCode,
+		FString& OutError);
+};

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
@@ -191,7 +191,7 @@ void FUnrealBridgeModule::StartupModule()
 	}
 
 	// ---- start the TCP server -----------------------------------------
-	Server = MakeShared<FUnrealBridgeServer>();
+	Server = MakeShared<FUnrealBridgeServer, ESPMode::ThreadSafe>();
 	FUnrealBridgeServer::FStartConfig StartCfg;
 	StartCfg.BindAddress = BindAddress;
 	StartCfg.Port = Port;
@@ -251,10 +251,10 @@ void FUnrealBridgeModule::StartupModule()
 	}
 
 	// ---- editor-ready gate --------------------------------------------
-	TWeakPtr<FUnrealBridgeServer> WeakServer = Server;
+	TWeakPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> WeakServer = Server;
 	auto OnMainFrameReady = [WeakServer](TSharedPtr<SWindow>, bool)
 	{
-		if (TSharedPtr<FUnrealBridgeServer> Pinned = WeakServer.Pin())
+		if (TSharedPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> Pinned = WeakServer.Pin())
 		{
 			Pinned->SetEditorReady(true);
 		}
@@ -267,12 +267,19 @@ void FUnrealBridgeModule::StartupModule()
 	}
 	else
 	{
-		MainFrame.OnMainFrameCreationFinished().AddLambda(OnMainFrameReady);
+		MainFrameReadyHandle = MainFrame.OnMainFrameCreationFinished().AddLambda(OnMainFrameReady);
 	}
 }
 
 void FUnrealBridgeModule::ShutdownModule()
 {
+	if (MainFrameReadyHandle.IsValid() && FModuleManager::Get().IsModuleLoaded(TEXT("MainFrame")))
+	{
+		IMainFrameModule& MainFrame = FModuleManager::GetModuleChecked<IMainFrameModule>(TEXT("MainFrame"));
+		MainFrame.OnMainFrameCreationFinished().Remove(MainFrameReadyHandle);
+		MainFrameReadyHandle.Reset();
+	}
+
 	BridgePerfSampler::Shutdown();
 	BridgePerfFrameHook::Unregister();
 	BridgeDebugState::Unregister();

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeModule.cpp
@@ -117,17 +117,6 @@ namespace
 		return BytesToHex(Digest, 8).ToLower();
 	}
 
-	/**
-	 * Find the editor's .uproject path for the running session. Used by the
-	 * discovery responder so clients can match by path as well as by name.
-	 */
-	FString ResolveProjectPath()
-	{
-		FString Path = FPaths::ConvertRelativePathToFull(
-			FPaths::Combine(FPaths::ProjectDir(), FString::Printf(TEXT("%s.uproject"), FApp::GetProjectName())));
-		Path.ReplaceInline(TEXT("\\"), TEXT("/"));
-		return Path;
-	}
 }
 
 void FUnrealBridgeModule::StartupModule()
@@ -206,9 +195,12 @@ void FUnrealBridgeModule::StartupModule()
 		return;
 	}
 
-	UE_LOG(LogUnrealBridgeModule, Log, TEXT("Server up on %s:%d%s"),
+	UE_LOG(LogUnrealBridgeModule, Log,
+		TEXT("Server up on %s:%d%s (protocol=%d instance=%s pid=%d project=%s)"),
 		*Server->GetBoundAddress(), Server->GetBoundPort(),
-		Server->HasToken() ? TEXT(" (token enforced)") : TEXT(""));
+		Server->HasToken() ? TEXT(" (token enforced)") : TEXT(""),
+		Server->GetProtocolVersion(), *Server->GetInstanceId(), Server->GetProcessId(),
+		*Server->GetProjectPath());
 
 	if (Server->HasToken())
 	{
@@ -232,7 +224,10 @@ void FUnrealBridgeModule::StartupModule()
 		DiscCfg.TcpBindAddress = Server->GetBoundAddress();
 		DiscCfg.TcpPort = Server->GetBoundPort();
 		DiscCfg.ProjectName = FApp::GetProjectName();
-		DiscCfg.ProjectPath = ResolveProjectPath();
+		DiscCfg.ProjectPath = Server->GetProjectPath();
+		DiscCfg.ProtocolVersion = Server->GetProtocolVersion();
+		DiscCfg.InstanceId = Server->GetInstanceId();
+		DiscCfg.ProcessId = Server->GetProcessId();
 		DiscCfg.EngineVersion = FEngineVersion::Current().ToString();
 		DiscCfg.TokenFingerprint = TokenFingerprint(Token);
 
@@ -240,14 +235,14 @@ void FUnrealBridgeModule::StartupModule()
 		if (!Discovery->StartService())
 		{
 			UE_LOG(LogUnrealBridgeModule, Warning,
-				TEXT("discovery failed to start — clients will need an explicit --endpoint=%s:%d"),
-				*Server->GetBoundAddress(), Server->GetBoundPort());
+				TEXT("discovery failed to start — direct clients need the full endpoint/instance/pid/project tuple from the Server up line"));
 			Discovery.Reset();
 		}
 	}
 	else
 	{
-		UE_LOG(LogUnrealBridgeModule, Log, TEXT("discovery disabled (opt-out) — clients need --endpoint="));
+		UE_LOG(LogUnrealBridgeModule, Log,
+			TEXT("discovery disabled (opt-out) — direct clients need the full endpoint/instance/pid/project tuple from the Server up line"));
 	}
 
 	// ---- editor-ready gate --------------------------------------------

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeProtocol.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeProtocol.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * protocol v2 的字段值与命令名事实源；Server、discovery 与契约测试共同引用。
+ * Source of truth for protocol-v2 field values and command names shared by Server, discovery, and contract tests.
+ */
+namespace UnrealBridgeProtocol
+{
+	constexpr int32 Version = 2;
+	constexpr const TCHAR* CommandField = TEXT("command");
+	constexpr const TCHAR* ExpectedField = TEXT("expected");
+	constexpr const TCHAR* RequestField = TEXT("request");
+	constexpr const TCHAR* ProtocolVersionField = TEXT("protocol_version");
+	constexpr const TCHAR* InstanceIdField = TEXT("instance_id");
+	constexpr const TCHAR* ProcessIdField = TEXT("pid");
+	constexpr const TCHAR* ProjectPathField = TEXT("project_path");
+
+	constexpr const TCHAR* ExactPrefix = TEXT("exact_");
+	constexpr const TCHAR* ExactExec = TEXT("exact_exec");
+	constexpr const TCHAR* ExactPing = TEXT("exact_ping");
+	constexpr const TCHAR* ExactGameThreadPing = TEXT("exact_gamethread_ping");
+	constexpr const TCHAR* ExactDebugResume = TEXT("exact_debug_resume");
+	constexpr const TCHAR* ExactModalStatus = TEXT("exact_modal_status");
+	constexpr const TCHAR* ExactModalAction = TEXT("exact_modal_action");
+
+	constexpr const TCHAR* ExactCapabilities[] = {
+		ExactExec,
+		ExactPing,
+		ExactGameThreadPing,
+		ExactDebugResume,
+		ExactModalStatus,
+		ExactModalAction,
+	};
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
@@ -1,5 +1,8 @@
 #include "UnrealBridgeServer.h"
 #include "UnrealBridgeCancellableWork.h"
+#include "UnrealBridgeEndpointIdentity.h"
+#include "UnrealBridgeExactRequestDispatcher.h"
+#include "UnrealBridgeProtocol.h"
 #include "IPythonScriptPlugin.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
@@ -643,6 +646,13 @@ bool FUnrealBridgeServer::Start(const FStartConfig& Config)
 		}
 	}
 
+	// 身份只在 listener 成功建立后生成；每次成功 Start 都得到新的 UUID。
+	// Identity is generated only after the listener succeeds; every successful Start receives a fresh UUID.
+	const FUnrealBridgeEndpointIdentity Identity = FUnrealBridgeEndpointIdentity::Create();
+	InstanceId = Identity.InstanceId;
+	ProjectPath = Identity.ProjectPath;
+	ProcessId = Identity.ProcessId;
+
 	Listener->OnConnectionAccepted().BindRaw(this, &FUnrealBridgeServer::OnConnectionAccepted);
 
 	// Register the GameThread ticker that drains the exec queue.
@@ -779,6 +789,11 @@ void FUnrealBridgeServer::Stop()
 bool FUnrealBridgeServer::IsRunning() const
 {
 	return bIsRunning;
+}
+
+int32 FUnrealBridgeServer::GetProtocolVersion()
+{
+	return UnrealBridgeProtocol::Version;
 }
 
 void FUnrealBridgeServer::SetEditorReady(bool bReady)
@@ -958,6 +973,11 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 	// 4. Build response
 	TSharedRef<FJsonObject> Response = MakeShared<FJsonObject>();
 	Response->SetStringField(TEXT("id"), RequestId);
+	FUnrealBridgeEndpointIdentity ResponseIdentity;
+	ResponseIdentity.InstanceId = InstanceId;
+	ResponseIdentity.ProjectPath = ProjectPath;
+	ResponseIdentity.ProcessId = ProcessId;
+	ResponseIdentity.AppendToResponse(Response);
 
 	// 4a. Token auth — only enforced when the server was started with a token
 	// (i.e. binding to a non-localhost interface). Constant-time compare so a
@@ -1006,22 +1026,53 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		}
 	}
 
-	FString Command;
-	Request->TryGetStringField(TEXT("command"), Command); // optional
-	CallRecord.Command = Command.IsEmpty() ? TEXT("exec") : Command;
+	FString WireCommand;
+	Request->TryGetStringField(UnrealBridgeProtocol::CommandField, WireCommand);
+	CallRecord.Command = WireCommand.IsEmpty() ? TEXT("<missing>") : WireCommand;
 
 	UE_LOG(LogUnrealBridge, Verbose,
 		TEXT("[%s] request id=%s cmd=%s payload=%u"),
-		*EndpointStr, *RequestId, Command.IsEmpty() ? TEXT("(exec)") : *Command, PayloadLen);
+		*EndpointStr, *RequestId, WireCommand.IsEmpty() ? TEXT("(missing)") : *WireCommand, PayloadLen);
 
-	if (Command == TEXT("ping"))
+	FUnrealBridgeAcceptedRequest AcceptedRequest;
+	FString DispatchErrorCode;
+	FString DispatchError;
+	const bool bExactRequestValid = FUnrealBridgeExactRequestDispatcher::TryDispatch(
+		Request,
+		ResponseIdentity,
+		[&AcceptedRequest](const FUnrealBridgeAcceptedRequest& Accepted)
+		{
+			AcceptedRequest = Accepted;
+		},
+		DispatchErrorCode,
+		DispatchError);
+	if (!bExactRequestValid)
+	{
+		Response->SetBoolField(TEXT("success"), false);
+		Response->SetStringField(TEXT("output"), TEXT(""));
+		Response->SetStringField(TEXT("error"), DispatchError);
+		Response->SetStringField(TEXT("error_code"), DispatchErrorCode);
+		Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
+	}
+	else
+	{
+		Request = AcceptedRequest.Payload;
+	}
+
+	const EUnrealBridgeExactCommand Command = AcceptedRequest.Command;
+	if (!bExactRequestValid)
+	{
+		// 唯一 dispatcher 拒绝后不进入任何命令 body、work admission 或 GameThread dispatch。
+		// After the sole dispatcher rejects, no command body, work admission, or GameThread dispatch is entered.
+	}
+	else if (Command == EUnrealBridgeExactCommand::Ping)
 	{
 		Response->SetBoolField(TEXT("success"), true);
 		Response->SetStringField(TEXT("output"), TEXT("pong"));
 		Response->SetStringField(TEXT("error"), TEXT(""));
 		Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
 	}
-	else if (Command == TEXT("debug_resume"))
+	else if (Command == EUnrealBridgeExactCommand::DebugResume)
 	{
 		// Recovery path for a stuck blueprint breakpoint.
 		//
@@ -1064,7 +1115,7 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		Response->SetStringField(TEXT("error"), TEXT(""));
 		Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
 	}
-	else if (Command == TEXT("gamethread_ping"))
+	else if (Command == EUnrealBridgeExactCommand::GameThreadPing)
 	{
 		// Probe whether the GameThread is responsive without going through
 		// the FTSTicker exec queue. Submits a no-op AsyncTask(GameThread)
@@ -1105,7 +1156,8 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		Response->SetNumberField(TEXT("latency_ms"), LatencyMs);
 		Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
 	}
-	else if (Command == TEXT("modal_status") || Command == TEXT("modal_action"))
+	else if (Command == EUnrealBridgeExactCommand::ModalStatus
+		|| Command == EUnrealBridgeExactCommand::ModalAction)
 	{
 		// This path intentionally bypasses both Python and the FTSTicker exec
 		// queue. It remains callable while an earlier exec is suspended inside
@@ -1137,7 +1189,7 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 						return UnrealBridgeModal::MakeResult(
 							false, TEXT(""), TEXT("server shutting down"), UnrealBridgeModal::FModalSnapshot());
 					}
-					if (Command == TEXT("modal_status"))
+					if (Command == EUnrealBridgeExactCommand::ModalStatus)
 					{
 						return UnrealBridgeModal::GetStatus();
 					}
@@ -1233,6 +1285,10 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		}
 	}
 
+	// modal result 会替换 Response 对象，因此在所有分支结束后再次写入权威 identity。
+	// Modal results replace the Response object, so append authoritative identity again after all branches.
+	ResponseIdentity.AppendToResponse(Response);
+
 	// Mirror the authoritative Response fields into the call record so
 	// every branch (ping / resume / exec / rejected-not-ready / etc.)
 	// logs consistent success/output/error sizes without bespoke wiring.
@@ -1269,14 +1325,14 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 	{
 		UE_LOG(LogUnrealBridge, Warning,
 			TEXT("[%s] send response header failed (id=%s cmd=%s)"),
-			*EndpointStr, *RequestId, *Command);
+			*EndpointStr, *RequestId, *WireCommand);
 		return;
 	}
 	if (!SendAll(ClientSocket, (const uint8*)Utf8Response.Get(), ResponseLen))
 	{
 		UE_LOG(LogUnrealBridge, Warning,
 			TEXT("[%s] send response body failed (id=%s cmd=%s len=%d)"),
-			*EndpointStr, *RequestId, *Command, ResponseLen);
+			*EndpointStr, *RequestId, *WireCommand, ResponseLen);
 		return;
 	}
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeServer.cpp
@@ -1,4 +1,5 @@
 #include "UnrealBridgeServer.h"
+#include "UnrealBridgeCancellableWork.h"
 #include "IPythonScriptPlugin.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
@@ -31,6 +32,22 @@ namespace UnrealBridgeLimits
 	// triggering an OOM in the editor via blind SetNumUninitialized.
 	constexpr int32 MaxRequestBytes = 10 * 1024 * 1024;
 }
+
+/**
+ * exec queue 的共享 control block；worker 等待它，GameThread ticker 尝试消费它。
+ * Shared exec-queue control block waited by a worker and claimed by the GameThread ticker.
+ */
+struct FUnrealBridgeServer::FPendingExec final
+{
+	FPendingExec(TFunction<FExecResult()>&& InBody, FString InRequestId)
+		: Work(MoveTemp(InBody))
+		, RequestId(MoveTemp(InRequestId))
+	{
+	}
+
+	TUnrealBridgeCancellableWork<FExecResult> Work;
+	FString RequestId;
+};
 
 // Modal-dialog inspection and actions deliberately live outside the normal
 // Python exec queue. A Slate modal loop does not tick FTSTicker, so an exec
@@ -495,22 +512,54 @@ namespace UnrealBridgeModal
 		return MakeResult(false, TEXT(""), TEXT("unsupported modal action"), Snapshot);
 	}
 
-	bool RunOnGameThread(TFunction<TSharedPtr<FJsonObject>()>&& Work,
-		TSharedPtr<FJsonObject>& OutResult, float TimeoutSeconds = 3.0f)
+	/** GameThread wait 的权威终态。 / Authoritative outcome of a bounded GameThread wait. */
+	enum class EGameThreadWorkWaitResult : uint8
 	{
-		auto Promise = MakeShared<TPromise<TSharedPtr<FJsonObject>>, ESPMode::ThreadSafe>();
-		TFuture<TSharedPtr<FJsonObject>> Future = Promise->GetFuture();
-		AsyncTask(ENamedThreads::GameThread, [Promise, Work = MoveTemp(Work)]() mutable
+		Completed,
+		CancelledBeforeStart,
+		AlreadyRunning,
+	};
+
+	EGameThreadWorkWaitResult RunOnGameThread(
+		TFunction<TSharedPtr<FJsonObject>()>&& Body,
+		TSharedPtr<FJsonObject>& OutResult,
+		float TimeoutSeconds = 3.0f)
+	{
+		using FModalWork = TUnrealBridgeCancellableWork<TSharedPtr<FJsonObject>>;
+		TSharedPtr<FModalWork, ESPMode::ThreadSafe> Pending =
+			MakeShared<FModalWork, ESPMode::ThreadSafe>(MoveTemp(Body));
+
+		AsyncTask(ENamedThreads::GameThread, [Pending]()
 		{
-			Promise->SetValue(Work());
+			// timeout 取消成功后，这个晚到 task 只会失败 claim，绝不执行 Slate body。
+			// After timeout cancellation wins, this late task can only fail its claim and never runs the Slate body.
+			Pending->TryExecute();
 		});
 
-		if (!Future.WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
+		if (Pending->WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
 		{
-			return false;
+			OutResult = Pending->GetResult();
+			return EGameThreadWorkWaitResult::Completed;
 		}
-		OutResult = Future.Get();
-		return OutResult.IsValid();
+
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		TSharedPtr<FJsonObject> CancelledResult;
+		if (Pending->TryCancel(MoveTemp(CancelledResult), ObservedState))
+		{
+			return EGameThreadWorkWaitResult::CancelledBeforeStart;
+		}
+		if (ObservedState == EUnrealBridgeWorkState::Completed)
+		{
+			// completion 与 deadline 同时发生时返回真实结果，不伪造 timeout。
+			// If completion races the deadline, return the real result instead of fabricating a timeout.
+			OutResult = Pending->GetResult();
+			return EGameThreadWorkWaitResult::Completed;
+		}
+		if (ObservedState == EUnrealBridgeWorkState::Cancelled)
+		{
+			return EGameThreadWorkWaitResult::CancelledBeforeStart;
+		}
+		return EGameThreadWorkWaitResult::AlreadyRunning;
 	}
 }
 
@@ -519,6 +568,7 @@ namespace UnrealBridgeModal
 // ─────────────────────────────────────────────────────────────
 
 FUnrealBridgeServer::FUnrealBridgeServer()
+	: WorkAdmission(MakeUnique<FUnrealBridgeWorkAdmissionGate>())
 {
 }
 
@@ -631,6 +681,7 @@ bool FUnrealBridgeServer::Start(const FStartConfig& Config)
 	});
 
 	bIsRunning = true;
+	WorkAdmission->Open();
 	UE_LOG(LogUnrealBridge, Log, TEXT("Listening on %s:%d%s"),
 		*BindAddressStr, ListenPort,
 		HasToken() ? TEXT(" (token auth enforced)") : TEXT(""));
@@ -639,19 +690,25 @@ bool FUnrealBridgeServer::Start(const FStartConfig& Config)
 
 void FUnrealBridgeServer::Stop()
 {
-	if (!bIsRunning)
+	if (!bIsRunning && !WorkAdmission->IsOpen())
 	{
 		return;
 	}
-	bIsRunning = false;
+	checkf(IsInGameThread(), TEXT("UnrealBridge Server must stop on the GameThread"));
 
-	// 1. Stop accepting new connections.
+	// 1. 先原子关闭 work admission；Close 返回后，accept/enqueue callback 均已离开。
+	// First close work admission atomically; after Close returns, accept/enqueue callbacks have left.
+	WorkAdmission->Close();
+	bIsRunning = false;
+	const FGraphEventArray WorkersToWait = ClientWorkerTasks;
+
+	// 2. Stop accepting new connections.
 	if (Listener.IsValid())
 	{
 		Listener.Reset();
 	}
 
-	// 2. Unregister GameThread ticker and editor delegates (items #11 #12).
+	// 3. Unregister GameThread ticker and editor delegates (items #11 #12).
 	if (TickHandle.IsValid())
 	{
 		FTSTicker::GetCoreTicker().RemoveTicker(TickHandle);
@@ -678,19 +735,19 @@ void FUnrealBridgeServer::Stop()
 		PieEndHandle.Reset();
 	}
 
-	// 3. Fulfill any queued execs with a shutdown error so worker threads
-	// waiting on TFuture wake up immediately.
+	// 4. 通过共同状态机取消 queued exec；gate 已关闭，所以 drain 后不能再有新 item。
+	// Cancel queued execs through the shared state machine; the closed gate prevents post-drain admission.
 	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending;
 	while (ExecQueue.Dequeue(Pending) && Pending.IsValid())
 	{
-		FExecResult R;
-		R.bSuccess = false;
-		R.Error = TEXT("server shutting down");
-		Pending->Promise.SetValue(MoveTemp(R));
+		FExecResult ShutdownResult;
+		ShutdownResult.bSuccess = false;
+		ShutdownResult.Error = TEXT("server shutting down");
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		Pending->Work.TryCancel(MoveTemp(ShutdownResult), ObservedState);
 	}
 
-	// 4. Force-close active client sockets so HandleClient's RecvAll
-	// unblocks immediately instead of waiting for its 5 s idle timeout.
+	// 5. Force-close active client sockets so HandleClient's RecvAll/SendAll unblocks.
 	{
 		FScopeLock Lock(&ActiveSocketsLock);
 		for (FSocket* S : ActiveSockets)
@@ -702,26 +759,21 @@ void FUnrealBridgeServer::Stop()
 		}
 	}
 
-	// 5. Bounded wait for AsyncTask workers to drain (item #12). Beyond
-	// the deadline we log and proceed — the workers will still finish
-	// their cleanup (DestroySocket, ActiveClients.Decrement) but
-	// ShutdownModule isn't held hostage to a stuck Python exec.
-	const double Deadline = FPlatformTime::Seconds() + 3.0;
-	while (ActiveClients.GetValue() > 0 && FPlatformTime::Seconds() < Deadline)
+	// 6. Module unload 不能留下任何 plugin-owned closure。等待完整 graph event 会覆盖
+	// lambda body、capture destructor 与 bookkeeping；GameThread wait 同时泵送 modal/ping task。
+	// Module unload cannot leave plugin-owned closures behind. Waiting on graph events covers the
+	// lambda body, capture destruction, and bookkeeping while the GameThread pumps modal/ping tasks.
+	if (WorkersToWait.Num() > 0)
 	{
-		FPlatformProcess::Sleep(0.01f);
+		FTaskGraphInterface::Get().WaitUntilTasksComplete(WorkersToWait, ENamedThreads::GameThread);
 	}
-	const int32 Stragglers = ActiveClients.GetValue();
-	if (Stragglers > 0)
-	{
-		UE_LOG(LogUnrealBridge, Warning,
-			TEXT("Stop(): %d client worker(s) still active after 3s drain timeout"),
-			Stragglers);
-	}
-	else
-	{
-		UE_LOG(LogUnrealBridge, Log, TEXT("Stop(): all client workers drained cleanly"));
-	}
+	FTaskGraphInterface::Get().ProcessThreadUntilIdle(ENamedThreads::GameThread);
+	ClientWorkerTasks.Reset();
+
+	checkf(ActiveClients.GetValue() == 0,
+		TEXT("UnrealBridge client graph events completed with %d active clients"),
+		ActiveClients.GetValue());
+	UE_LOG(LogUnrealBridge, Log, TEXT("Stop(): all client workers and GameThread closures drained cleanly"));
 }
 
 bool FUnrealBridgeServer::IsRunning() const
@@ -750,48 +802,64 @@ bool FUnrealBridgeServer::IsEditorReady() const
 bool FUnrealBridgeServer::OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& ClientEndpoint)
 {
 	const FString EndpointStr = ClientEndpoint.ToString();
+	bool bAccepted = false;
 
-	// Bound concurrent clients so a runaway caller can't saturate the
-	// AsyncTask background pool and starve other editor work. When we're
-	// over capacity we return false so FTcpListener destroys the accepted
-	// socket itself — the client sees a clean connection reset rather than
-	// a silent hang.
-	const int32 Active = ActiveClients.Increment();
-	if (Active > MaxConcurrentClients)
+	// gate callback 同时完成容量检查、graph-event 注册与 task dispatch；Stop::Close
+	// 返回后不会出现“已快照 worker 列表之后才注册”的尾随 closure。
+	// The gate callback performs capacity check, graph-event registration, and dispatch together;
+	// after Stop::Close returns, no trailing closure can register after the worker snapshot.
+	const bool bAdmissionOpen = WorkAdmission->TryAdmit([this, ClientSocket, EndpointStr, &bAccepted]()
 	{
-		ActiveClients.Decrement();
-		UE_LOG(LogUnrealBridge, Warning,
-			TEXT("[conn] rejecting %s — at concurrency limit (%d/%d)"),
-			*EndpointStr, Active - 1, MaxConcurrentClients);
-		return false;
-	}
-
-	UE_LOG(LogUnrealBridge, Verbose, TEXT("[conn] accepted %s (active=%d)"), *EndpointStr, Active);
-
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, ClientSocket, EndpointStr]()
-	{
-		// Register socket so Stop() can force-close us (item #6).
+		ClientWorkerTasks.RemoveAll([](const FGraphEventRef& Task)
 		{
-			FScopeLock Lock(&ActiveSocketsLock);
-			ActiveSockets.Add(ClientSocket);
+			return !Task.IsValid() || Task->IsComplete();
+		});
+
+		const int32 Active = ActiveClients.Increment();
+		if (Active > MaxConcurrentClients)
+		{
+			ActiveClients.Decrement();
+			UE_LOG(LogUnrealBridge, Warning,
+				TEXT("[conn] rejecting %s — at concurrency limit (%d/%d)"),
+				*EndpointStr, Active - 1, MaxConcurrentClients);
+			return;
 		}
 
-		HandleClient(ClientSocket, EndpointStr);
+		UE_LOG(LogUnrealBridge, Verbose,
+			TEXT("[conn] accepted %s (active=%d)"), *EndpointStr, Active);
 
-		{
-			FScopeLock Lock(&ActiveSocketsLock);
-			ActiveSockets.Remove(ClientSocket);
-		}
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Self = AsShared();
+		FGraphEventRef WorkerTask = FFunctionGraphTask::CreateAndDispatchWhenReady(
+			[Self, ClientSocket, EndpointStr]()
+			{
+				// Register socket so Stop() can force-close us (item #6).
+				{
+					FScopeLock Lock(&Self->ActiveSocketsLock);
+					Self->ActiveSockets.Add(ClientSocket);
+				}
 
-		ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
-		if (SocketSubsystem)
-		{
-			SocketSubsystem->DestroySocket(ClientSocket);
-		}
-		ActiveClients.Decrement();
+				Self->HandleClient(ClientSocket, EndpointStr);
+
+				{
+					FScopeLock Lock(&Self->ActiveSocketsLock);
+					Self->ActiveSockets.Remove(ClientSocket);
+				}
+
+				ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+				if (SocketSubsystem)
+				{
+					SocketSubsystem->DestroySocket(ClientSocket);
+				}
+				Self->ActiveClients.Decrement();
+			},
+			TStatId(),
+			nullptr,
+			ENamedThreads::AnyBackgroundThreadNormalTask);
+		ClientWorkerTasks.Add(MoveTemp(WorkerTask));
+		bAccepted = true;
 	});
 
-	return true;
+	return bAdmissionOpen && bAccepted;
 }
 
 void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& EndpointStr)
@@ -978,8 +1046,13 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		// Together these pop the debug-mode stack and let ProcessEvent
 		// return, which unblocks the stuck Python exec, which unblocks the
 		// TCP response to the original caller.
-		AsyncTask(ENamedThreads::GameThread, []()
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
+		AsyncTask(ENamedThreads::GameThread, [ServerOwner]()
 		{
+			if (!ServerOwner->IsRunning())
+			{
+				return;
+			}
 			FKismetDebugUtilities::RequestAbortingExecution();
 			if (FSlateApplication::IsInitialized())
 			{
@@ -1015,9 +1088,10 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		TFuture<bool> ProbeFuture = Probe->GetFuture();
 		const double ProbeT0 = FPlatformTime::Seconds();
 
-		AsyncTask(ENamedThreads::GameThread, [Probe]()
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
+		AsyncTask(ENamedThreads::GameThread, [Probe, ServerOwner]()
 		{
-			Probe->SetValue(true);
+			Probe->SetValue(ServerOwner->IsRunning());
 		});
 
 		const bool bAlive = ProbeFuture.WaitFor(FTimespan::FromSeconds(ProbeTimeout));
@@ -1050,30 +1124,52 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 		bool bChecked = false;
 		const bool bHasChecked = Request->TryGetBoolField(TEXT("checked"), bChecked);
 
+		TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> ServerOwner = AsShared();
 		TSharedPtr<FJsonObject> ModalResult;
-		const bool bCompleted = UnrealBridgeModal::RunOnGameThread(
-			[Command, ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked]()
-			{
-				if (Command == TEXT("modal_status"))
+		const UnrealBridgeModal::EGameThreadWorkWaitResult WaitResult =
+			UnrealBridgeModal::RunOnGameThread(
+				[ServerOwner, Command, ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked]()
 				{
-					return UnrealBridgeModal::GetStatus();
-				}
-				return UnrealBridgeModal::PerformAction(
-					ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked);
-			},
-			ModalResult);
+					// Stop 关闭 admission 后，晚到 task 只能返回 shutdown，不得触碰 Slate。
+					// After Stop closes admission, a late task may only return shutdown and must not touch Slate.
+					if (!ServerOwner->IsRunning())
+					{
+						return UnrealBridgeModal::MakeResult(
+							false, TEXT(""), TEXT("server shutting down"), UnrealBridgeModal::FModalSnapshot());
+					}
+					if (Command == TEXT("modal_status"))
+					{
+						return UnrealBridgeModal::GetStatus();
+					}
+					return UnrealBridgeModal::PerformAction(
+						ExpectedSnapshot, Action, ControlId, Value, bChecked, bHasChecked);
+				},
+				ModalResult);
 
-		if (bCompleted)
+		if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::Completed
+			&& ModalResult.IsValid())
 		{
 			Response = ModalResult.ToSharedRef();
 			Response->SetStringField(TEXT("id"), RequestId);
 		}
 		else
 		{
+			FString Error;
+			if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::CancelledBeforeStart)
+			{
+				Error = TEXT("GameThread did not service the modal request within 3.0s; queued modal work cancelled before execution");
+			}
+			else if (WaitResult == UnrealBridgeModal::EGameThreadWorkWaitResult::AlreadyRunning)
+			{
+				Error = TEXT("modal request timed out after 3.0s; work already started and outcome is unknown");
+			}
+			else
+			{
+				Error = TEXT("modal request completed without a result");
+			}
 			Response->SetBoolField(TEXT("success"), false);
 			Response->SetStringField(TEXT("output"), TEXT(""));
-			Response->SetStringField(TEXT("error"),
-				TEXT("GameThread did not service the modal request within 3.0s"));
+			Response->SetStringField(TEXT("error"), Error);
 			Response->SetBoolField(TEXT("ready"), (bool)bEditorReady);
 		}
 	}
@@ -1193,40 +1289,99 @@ void FUnrealBridgeServer::HandleClient(FSocket* ClientSocket, const FString& End
 // Python execution pipeline
 // ─────────────────────────────────────────────────────────────
 //
-// Worker threads enqueue heap-allocated FPendingExec and wait on the
-// associated TFuture. A single FTSTicker consumer on the GameThread drains
-// the queue one item per frame, guarded by bExecInFlight. This design:
-//   - Eliminates the reentrancy crash caused by AsyncTask(GameThread) being
-//     pulled off the task-graph queue during Python-triggered TaskGraph pumps.
-//   - Removes the dangling-reference / event-pool-reuse bug from the old
-//     per-request FEvent scheme: TSharedPtr<FPendingExec> keeps the promise
-//     alive until the ticker fulfills it, regardless of whether the worker
-//     has already returned a timeout to its client.
+// worker 把共享 FPendingExec control block 入队并等待；GameThread 的单一 FTSTicker
+// 每帧最多消费一项，并由 bExecInFlight 防止重入。共同状态机保证：保留 Python 的
+// 非重入 ticker 调度；timeout/shutdown/ticker 只有一个 terminal winner；ticker
+// 取到 cancelled tombstone 时不会执行 body。
+// Workers enqueue shared FPendingExec control blocks and wait. One GameThread
+// FTSTicker drains at most one item per frame under bExecInFlight. The shared
+// state machine preserves non-reentrant Python dispatch, gives timeout/shutdown/
+// ticker one terminal winner, and makes cancelled queue tombstones harmless.
 // ─────────────────────────────────────────────────────────────
 
 FUnrealBridgeServer::FExecResult FUnrealBridgeServer::EnqueueAndWaitForExec(
 	const FString& Script, float TimeoutSeconds, const FString& RequestId)
 {
-	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending = MakeShared<FPendingExec, ESPMode::ThreadSafe>();
-	Pending->Script = Script;
-	Pending->TimeoutSeconds = TimeoutSeconds;
-	Pending->RequestId = RequestId;
-
-	TFuture<FExecResult> Future = Pending->Promise.GetFuture();
-	ExecQueue.Enqueue(Pending);
-
-	const bool bReady = Future.WaitFor(FTimespan::FromSeconds(TimeoutSeconds));
-	if (!bReady)
+	TFunction<FExecResult()> Body = [this, Script]()
 	{
-		FExecResult R;
-		R.bSuccess = false;
-		R.Error = FString::Printf(TEXT("exec timeout after %.1fs"), TimeoutSeconds);
-		// Leave the promise alone — the ticker will still fulfill it later,
-		// but Pending's shared-ptr means that's safe and leaks nothing.
-		return R;
+		return DoPythonExec(Script);
+	};
+	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending =
+		MakeShared<FPendingExec, ESPMode::ThreadSafe>(MoveTemp(Body), RequestId);
+
+	const bool bEnqueued = WorkAdmission->TryAdmit([this, &Pending]()
+	{
+		ExecQueue.Enqueue(Pending);
+	});
+	if (!bEnqueued)
+	{
+		FExecResult ShutdownResult;
+		ShutdownResult.bSuccess = false;
+		ShutdownResult.Error = TEXT("server shutting down");
+		return ShutdownResult;
 	}
-	return Future.Get();
+
+	if (Pending->Work.WaitFor(FTimespan::FromSeconds(TimeoutSeconds)))
+	{
+		return Pending->Work.GetResult();
+	}
+
+	FExecResult TimeoutResult;
+	TimeoutResult.bSuccess = false;
+	TimeoutResult.Error = FString::Printf(
+		TEXT("exec timeout after %.1fs; queued work cancelled before execution"),
+		TimeoutSeconds);
+
+	EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+	if (Pending->Work.TryCancel(MoveTemp(TimeoutResult), ObservedState))
+	{
+		return Pending->Work.GetResult();
+	}
+	if (ObservedState == EUnrealBridgeWorkState::Completed
+		|| ObservedState == EUnrealBridgeWorkState::Cancelled)
+	{
+		// completion/shutdown 与 deadline 同时发生时返回权威 terminal result。
+		// If completion/shutdown races the deadline, return the authoritative terminal result.
+		return Pending->Work.GetResult();
+	}
+
+	FExecResult RunningResult;
+	RunningResult.bSuccess = false;
+	RunningResult.Error = FString::Printf(
+		TEXT("exec timeout after %.1fs; work already started and outcome is unknown"),
+		TimeoutSeconds);
+	return RunningResult;
 }
+
+#if WITH_DEV_AUTOMATION_TESTS
+bool FUnrealBridgeServer::EnqueueExecForTesting(
+	TFunction<void()>&& Body,
+	bool bCancelBeforeConsume,
+	const FString& RequestId)
+{
+	TFunction<FExecResult()> ExecBody = [Body = MoveTemp(Body)]() mutable
+	{
+		Body();
+		FExecResult Result;
+		Result.bSuccess = true;
+		return Result;
+	};
+	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending =
+		MakeShared<FPendingExec, ESPMode::ThreadSafe>(MoveTemp(ExecBody), RequestId);
+	const bool bEnqueued = WorkAdmission->TryAdmit([this, &Pending]()
+	{
+		ExecQueue.Enqueue(Pending);
+	});
+	if (bEnqueued && bCancelBeforeConsume)
+	{
+		FExecResult CancelledResult;
+		CancelledResult.Error = TEXT("cancelled by automation driver");
+		EUnrealBridgeWorkState ObservedState = EUnrealBridgeWorkState::Queued;
+		Pending->Work.TryCancel(MoveTemp(CancelledResult), ObservedState);
+	}
+	return bEnqueued;
+}
+#endif
 
 bool FUnrealBridgeServer::TickConsumeQueue(float /*DeltaTime*/)
 {
@@ -1239,16 +1394,27 @@ bool FUnrealBridgeServer::TickConsumeQueue(float /*DeltaTime*/)
 		return true; // belt-and-suspenders guard against ticker reentrancy
 	}
 
+	// 同一 tick 丢弃任意数量的 cancelled tombstone，但最多执行一个 Python body。
+	// Discard any number of cancelled tombstones in this tick, but execute at most one Python body.
 	TSharedPtr<FPendingExec, ESPMode::ThreadSafe> Pending;
-	if (!ExecQueue.Dequeue(Pending) || !Pending.IsValid())
+	while (ExecQueue.Dequeue(Pending))
 	{
-		return true;
-	}
+		if (!Pending.IsValid())
+		{
+			continue;
+		}
 
-	bExecInFlight = true;
-	FExecResult Result = DoPythonExec(Pending->Script);
-	Pending->Promise.SetValue(MoveTemp(Result));
-	bExecInFlight = false;
+		bExecInFlight = true;
+		const bool bExecuted = Pending->Work.TryExecute();
+		bExecInFlight = false;
+		if (bExecuted)
+		{
+			return true;
+		}
+
+		UE_LOG(LogUnrealBridge, Verbose,
+			TEXT("Skipping cancelled exec id=%s"), *Pending->RequestId);
+	}
 	return true;
 }
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeModule.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeModule.h
@@ -13,6 +13,7 @@ public:
 	virtual void ShutdownModule() override;
 
 private:
-	TSharedPtr<FUnrealBridgeServer> Server;
+	TSharedPtr<FUnrealBridgeServer, ESPMode::ThreadSafe> Server;
 	TUniquePtr<FBridgeDiscoveryService> Discovery;
+	FDelegateHandle MainFrameReadyHandle;
 };

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
@@ -17,14 +17,12 @@ class FUnrealBridgeWorkAdmissionGate;
  * TCP server that listens for incoming connections and executes Python scripts
  * in the Unreal Editor's Python interpreter.
  *
- * Protocol: Length-prefixed JSON frames
- *   Request:  <4 bytes big-endian length><JSON: {"id":"...", "script":"...", "timeout":30}>
- *   Response: <4 bytes big-endian length><JSON: {"id":"...", "success":bool, "output":"...", "error":"..."}>
+ * Protocol: Length-prefixed protocol-v2 JSON frames
+ *   Request:  <length><JSON: {"id":"...", "command":"exact_exec", "expected":{...}, "request":{"script":"..."}}>
+ *   Response: <length><JSON: {"id":"...", "success":bool, "output":"...", "error":"...", "instance_id":"..."}>
  *
- * Special commands:
- *   {"id":"...", "command":"ping"} -> {"id":"...", "success":true, "output":"pong", "error":""}
- *   {"id":"...", "command":"modal_status"} -> active Slate modal snapshot
- *   {"id":"...", "command":"modal_action", "snapshot":"...", ...} -> guarded modal interaction
+ * 所有命令必须使用 exact_* wire form，并在任何副作用调度前通过启动实例身份验证。
+ * Every command must use the exact_* wire form and pass Server-start identity validation before side-effect dispatch.
  */
 class FUnrealBridgeServer : public TSharedFromThis<FUnrealBridgeServer, ESPMode::ThreadSafe>
 {
@@ -73,6 +71,18 @@ public:
 
 	/** True if a token was set and request-time auth is enforced. */
 	bool HasToken() const { return !Token.IsEmpty(); }
+
+	/** 本次 Server 启动的不可复用 UUID。 / Non-reusable UUID for this Server start. */
+	const FString& GetInstanceId() const { return InstanceId; }
+
+	/** TCP/discovery 共同使用且客户端必须逐字复制的 wire-canonical 工程路径。 / Wire-canonical project path shared by TCP/discovery and copied verbatim by clients. */
+	const FString& GetProjectPath() const { return ProjectPath; }
+
+	/** exact identity 中冻结的当前进程 ID。 / Current process ID frozen into exact identity. */
+	int32 GetProcessId() const { return ProcessId; }
+
+	/** 当前 exact-wire 协议版本。 / Current exact-wire protocol version. */
+	static int32 GetProtocolVersion();
 
 	/**
 	 * Mark the editor as fully initialized (main frame created). Until this is
@@ -129,6 +139,9 @@ private:
 	int32 ListenPort = 0;
 	FString BindAddressStr = TEXT("127.0.0.1");
 	FString Token;
+	FString InstanceId;
+	FString ProjectPath;
+	int32 ProcessId = 0;
 	FThreadSafeBool bIsRunning = false;
 	FThreadSafeBool bEditorReady = false;
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeServer.h
@@ -6,9 +6,12 @@
 #include "Containers/Queue.h"
 #include "Containers/Ticker.h"
 #include "Async/Future.h"
+#include "Async/TaskGraphInterfaces.h"
 #include "Containers/Set.h"
 #include "Misc/ScopeLock.h"
 #include "Interfaces/IPv4/IPv4Address.h"
+
+class FUnrealBridgeWorkAdmissionGate;
 
 /**
  * TCP server that listens for incoming connections and executes Python scripts
@@ -23,7 +26,7 @@
  *   {"id":"...", "command":"modal_status"} -> active Slate modal snapshot
  *   {"id":"...", "command":"modal_action", "snapshot":"...", ...} -> guarded modal interaction
  */
-class FUnrealBridgeServer : public TSharedFromThis<FUnrealBridgeServer>
+class FUnrealBridgeServer : public TSharedFromThis<FUnrealBridgeServer, ESPMode::ThreadSafe>
 {
 public:
 	/** Configuration for Start — replaces the legacy `int32 Port` signature. */
@@ -80,6 +83,13 @@ public:
 	bool IsEditorReady() const;
 
 private:
+#if WITH_DEV_AUTOMATION_TESTS
+	friend class FUnrealBridgeServerTestAccessor;
+
+	/** 为确定性 Automation 注入不调用 Python 的 exec body。 / Inject a non-Python exec body for deterministic Automation. */
+	bool EnqueueExecForTesting(TFunction<void()>&& Body, bool bCancelBeforeConsume, const FString& RequestId);
+#endif
+
 	/** Called by FTcpListener when a new client connects. */
 	bool OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& ClientEndpoint);
 
@@ -101,18 +111,10 @@ private:
 	};
 
 	/**
-	 * A queued exec request. Heap-allocated and shared between the worker
-	 * thread (which waits on Promise's future) and the GameThread ticker
-	 * consumer (which fulfills Promise). Shared ownership guarantees no
-	 * dangling references if the worker times out before the ticker runs.
+	 * queued exec 的私有 control block；定义留在 Server.cpp，避免把调度细节暴露为公共 API。
+	 * Private queued-exec control block, defined in Server.cpp so scheduling details stay out of the public API.
 	 */
-	struct FPendingExec
-	{
-		FString Script;
-		float TimeoutSeconds = 30.0f;
-		FString RequestId;
-		TPromise<FExecResult> Promise;
-	};
+	struct FPendingExec;
 
 	/** Enqueue a script for GameThread execution and block on the future. */
 	FExecResult EnqueueAndWaitForExec(const FString& Script, float TimeoutSeconds, const FString& RequestId);
@@ -130,13 +132,19 @@ private:
 	FThreadSafeBool bIsRunning = false;
 	FThreadSafeBool bEditorReady = false;
 
-	// Exec pipeline (item #1 of server stability plan).
+	// exec admission 与 shutdown 由同一 gate 排序；Close 后 queue 不能再收到新 work。
+	// One gate orders exec admission against shutdown; no work can enter the queue after Close.
+	TUniquePtr<FUnrealBridgeWorkAdmissionGate> WorkAdmission;
 	TQueue<TSharedPtr<FPendingExec, ESPMode::ThreadSafe>, EQueueMode::Mpsc> ExecQueue;
 	FTSTicker::FDelegateHandle TickHandle;
 	bool bExecInFlight = false; // GameThread-only, no atomic needed
 
+	// client worker graph events 让 Stop 等待 closure 真正销毁，而不只是等待 raw counter 归零。
+	// Client worker graph events let Stop wait for closure destruction, not merely a raw counter reaching zero.
+	FGraphEventArray ClientWorkerTasks;
+
 	// Connection limit (item #5). Atomic because we increment/decrement from
-	// the listener thread (accept path) and the AsyncTask worker (completion).
+	// the listener thread (accept path) and the task-graph worker (completion).
 	FThreadSafeCounter ActiveClients;
 	static constexpr int32 MaxConcurrentClients = 16;
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ bridge.py exec "print('hello from UE')"
 bridge.py exec-file my_script.py
 ```
 
-Flags (all optional — the common case works with no flags):
+Discovery-mode flags are optional — the common case works with no flags:
 
 - `--project=<name|path>` — disambiguate when >1 editors are running
-- `--endpoint=host:port` — skip discovery, connect directly (also env `UNREAL_BRIDGE_ENDPOINT`)
 - `--token=<secret>` — only when the server binds non-loopback (also env `UNREAL_BRIDGE_TOKEN`)
 - `--timeout` (default 30s), `--json`, `--discovery-timeout=<ms>` (default 800)
+
+Direct mode is one inseparable tuple: `--endpoint=host:port --instance-id=<uuid> --expected-pid=<pid> --expected-project-path=<uproject>`. Copy the instance, PID, and project-path strings verbatim from one discovery response or Server startup line; do not change path separators or letter case. Matching `UNREAL_BRIDGE_ENDPOINT`, `UNREAL_BRIDGE_INSTANCE_ID`, `UNREAL_BRIDGE_PID`, and `UNREAL_BRIDGE_PROJECT_PATH` environment variables are also supported.
 
 `bridge.py list-editors` sends a probe and lists every editor that answered — handy for multi-editor setups.
 
@@ -241,15 +242,17 @@ source checkout invalidated the recorded path.
 
 Two channels:
 
-1. **UDP discovery** on port `9876`. The client sends the same request-id-bearing `probe` to LAN multicast `239.255.42.99` and local loopback `127.0.0.1`, then de-duplicates replies by editor PID. Multicast preserves LAN/multi-editor discovery; loopback keeps local discovery reliable when Windows, a VPN, or a virtual NIC drops multicast loopback. Every editor replies with its bound TCP address + port + token fingerprint. Multiple editors coexist via `SO_REUSEADDR`.
+1. **UDP discovery v2** on port `9876`. The client sends the same request-id-bearing `probe` to LAN multicast `239.255.42.99` and local loopback `127.0.0.1`, rejects malformed/legacy/incomplete replies, then de-duplicates by Server-start UUID. Every editor replies with `protocol_version`, `instance_id`, PID, one wire-canonical project-path string, TCP endpoint, capabilities, and token fingerprint. The six listed exact commands are the minimum required capability set; unique future capabilities are allowed. When a Server advertises a wildcard TCP bind, the client connects to the UDP response source IP. Multiple editors coexist via `SO_REUSEADDR`.
 
-2. **TCP data** on the port the editor reports in its discovery response (OS-assigned; `127.0.0.1` by default). Length-prefixed JSON:
+2. **TCP data** on the port the editor reports in its discovery response (OS-assigned; `127.0.0.1` by default). Every request freezes the discovered identity; every response echoes it and is rechecked. Length-prefixed JSON:
 
 ```
-Request :  [4-byte big-endian length][{"id","script","timeout","token?"}]
-Response:  [4-byte big-endian length][{"id","success","output","error"}]
-Ping    :  {"id","command":"ping"}  →  pong
+Request :  [4-byte big-endian length][{"id","command":"exact_exec","expected":{...},"request":{"script","timeout"},"token?"}]
+Response:  [4-byte big-endian length][{"id","success","output","error","protocol_version","instance_id","pid","project_path"}]
+Ping    :  {"command":"exact_ping","expected":{...},"request":{}}  →  pong
 ```
+
+The nested `request` object makes exact commands fail safely against a legacy server: no Python script exists at the legacy top level. Missing/mismatched identity and unknown/legacy wire forms are rejected by the production dispatcher before any command body, work admission, or GameThread dispatch. `project_path` is a wire identity, not a filesystem equivalence check: every OS requires the exact discovery/startup string. Client response frames are limited to 10 MiB and must contain a non-empty UTF-8 JSON object.
 
 Token auth kicks in automatically when the server binds non-loopback; the client reads the token from `<Project>/Saved/UnrealBridge/token.txt` and includes it in every request.
 
@@ -295,7 +298,7 @@ UnrealBridge/
 ## Safety
 
 - Every level-edit op is wrapped in `FScopedTransaction` — Ctrl+Z in the editor reverts anything the bridge did.
-- The TCP server binds to `127.0.0.1` only; it is not reachable from the network.
+- The TCP server binds to `127.0.0.1` by default. Non-loopback binding is explicitly supported only with token authentication and makes the endpoint reachable from the selected network interfaces.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,12 +169,13 @@ bridge.py exec "print('hello from UE')"
 bridge.py exec-file my_script.py
 ```
 
-参数（全部可选，常规使用可以一个都不传）：
+发现模式参数均为可选，常规使用可以一个都不传：
 
 - `--project=<名称|路径>` —— 同时跑多个编辑器时用来挑一个
-- `--endpoint=host:port` —— 跳过发现直连（或环境变量 `UNREAL_BRIDGE_ENDPOINT`）
 - `--token=<密钥>` —— 仅当 server 绑定非 loopback 时需要（或 `UNREAL_BRIDGE_TOKEN`）
 - `--timeout`（默认 30 秒）、`--json`、`--discovery-timeout=<ms>`（默认 800）
+
+直连模式必须把四项视为不可拆分的元组：`--endpoint=host:port --instance-id=<uuid> --expected-pid=<pid> --expected-project-path=<uproject>`。instance、PID 与工程路径必须逐字复制同一次 discovery 响应或 Server 启动日志，不得改写路径分隔符或大小写；也可使用对应的 `UNREAL_BRIDGE_ENDPOINT`、`UNREAL_BRIDGE_INSTANCE_ID`、`UNREAL_BRIDGE_PID`、`UNREAL_BRIDGE_PROJECT_PATH` 环境变量。
 
 `bridge.py list-editors` 发一次探测并列出所有响应的编辑器 —— 多编辑器场景的诊断快捷命令。
 
@@ -240,15 +241,17 @@ python .claude/skills/unreal-bridge/scripts/rebuild_relaunch.py  # 动到反射
 
 两个通道：
 
-1. **UDP 发现**：端口 `9876`。客户端把带同一 request_id 的 `probe`（可带 project 过滤器）同时发往局域网多播 `239.255.42.99` 和本机回环 `127.0.0.1`，并按编辑器 PID 去重。多播保留局域网/多编辑器发现，回环探测则避免 Windows、VPN 或虚拟网卡丢弃多播回环时导致本机发现失效。每个编辑器单播回自己的 TCP 绑定地址 + 端口 + token 指纹，多编辑器通过 `SO_REUSEADDR` 共存。
+1. **UDP 发现 v2**：端口 `9876`。客户端把带同一 request_id 的 `probe` 同时发往局域网多播 `239.255.42.99` 和本机回环 `127.0.0.1`，拒绝畸形、旧版或字段不完整的响应，再按每次 Server 启动生成的 UUID 去重。每个编辑器返回 `protocol_version`、`instance_id`、PID、唯一 wire-canonical 工程路径、TCP endpoint、capabilities 与 token 指纹。六个 exact command 是最低必需 capability 集；允许不重复的未来扩展项。Server 广告通配 TCP bind 时，客户端使用 UDP 响应源 IP。多编辑器通过 `SO_REUSEADDR` 共存。
 
-2. **TCP 数据通道**：端口由编辑器在发现响应里给出（OS 分配，默认 `127.0.0.1`）。长度前缀 JSON：
+2. **TCP 数据通道**：端口由编辑器在发现响应里给出（OS 分配，默认 `127.0.0.1`）。每个请求冻结发现到的身份，每个响应回显并由客户端复核。长度前缀 JSON：
 
 ```
-请求:  [4 字节大端长度][{"id","script","timeout","token?"}]
-响应:  [4 字节大端长度][{"id","success","output","error"}]
-Ping:  {"id","command":"ping"}  →  pong
+请求:  [4 字节大端长度][{"id","command":"exact_exec","expected":{...},"request":{"script","timeout"},"token?"}]
+响应:  [4 字节大端长度][{"id","success","output","error","protocol_version","instance_id","pid","project_path"}]
+Ping:  {"command":"exact_ping","expected":{...},"request":{}}  →  pong
 ```
+
+`request` 嵌套对象确保 exact command 落到旧 Server 时不会出现可执行的顶层 `script`。缺失/错误身份、未知或旧 wire form 都由生产 dispatcher 在任何 command body、work admission 或 GameThread dispatch 前拒绝。`project_path` 是 wire identity 而不是文件系统等价检查：所有平台都要求逐字匹配 discovery/启动值。客户端响应帧上限为 10 MiB，且必须是非空 UTF-8 JSON object。
 
 当 server 绑定非 loopback 时自动启用 token 鉴权；客户端从 `<Project>/Saved/UnrealBridge/token.txt` 读取并在每个请求里带上。
 

--- a/tools/test_bridge_discovery.py
+++ b/tools/test_bridge_discovery.py
@@ -13,11 +13,7 @@ from unittest import mock
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
-    / ".claude"
-    / "skills"
-    / "unreal-bridge"
-    / "scripts"
-    / "bridge_discovery.py"
+    / ".claude" / "skills" / "unreal-bridge" / "scripts" / "bridge_discovery.py"
 )
 SPEC = importlib.util.spec_from_file_location("bridge_discovery", MODULE_PATH)
 if SPEC is None or SPEC.loader is None:
@@ -28,9 +24,14 @@ SPEC.loader.exec_module(bridge_discovery)
 
 
 class FakeDiscoverySocket:
-    def __init__(self, *, fail_hosts=(), response_count=1):
+    def __init__(self, *, fail_hosts=(), response_count=1, response_overrides=None,
+                 response_sequence=None, source_host="127.0.0.1"):
         self.fail_hosts = set(fail_hosts)
-        self.response_count = response_count
+        self.response_overrides = dict(response_overrides or {})
+        self.response_sequence = (list(response_sequence)
+                                  if response_sequence is not None
+                                  else [dict(self.response_overrides) for _ in range(response_count)])
+        self.source_host = source_host
         self.request_id = ""
         self.targets = []
         self.closed = False
@@ -50,14 +51,13 @@ class FakeDiscoverySocket:
     def settimeout(self, _timeout):
         pass
 
-    def recvfrom(self, _max_size):
-        if self.response_count <= 0:
-            raise socket.timeout()
-        self.response_count -= 1
-        payload = json.dumps({
-            "v": 1,
+    def _valid_response(self):
+        return {
+            "v": bridge_discovery.PROTOCOL_VERSION,
+            "protocol_version": bridge_discovery.PROTOCOL_VERSION,
             "type": "response",
             "request_id": self.request_id,
+            "instance_id": "11111111-2222-4333-8444-555555555555",
             "pid": 4242,
             "project": "TestProject",
             "project_path": "C:/Projects/TestProject/TestProject.uproject",
@@ -65,8 +65,22 @@ class FakeDiscoverySocket:
             "tcp_bind": "127.0.0.1",
             "tcp_port": 32123,
             "token_fingerprint": "",
-        }).encode("utf-8")
-        return payload, ("127.0.0.1", 9876)
+            "capabilities": list(bridge_discovery.EXACT_CAPABILITIES),
+        }
+
+    def recvfrom(self, _max_size):
+        if not self.response_sequence:
+            raise socket.timeout()
+        item = self.response_sequence.pop(0)
+        if isinstance(item, bytes):
+            payload = item
+        elif isinstance(item, tuple) and item[0] == "root":
+            payload = json.dumps(item[1]).encode("utf-8")
+        else:
+            response = self._valid_response()
+            response.update(item)
+            payload = json.dumps(response).encode("utf-8")
+        return payload, (self.source_host, 9876)
 
     def close(self):
         self.closed = True
@@ -74,44 +88,100 @@ class FakeDiscoverySocket:
 
 class DiscoveryTests(unittest.TestCase):
     def run_discovery(self, fake_socket):
-        with mock.patch.object(
-            bridge_discovery.socket, "socket", return_value=fake_socket
-        ):
+        with mock.patch.object(bridge_discovery.socket, "socket", return_value=fake_socket):
             return bridge_discovery.discover(timeout_ms=10)
 
-    def test_multicast_and_loopback_responses_are_deduplicated_by_pid(self):
+    def test_multicast_and_loopback_responses_are_deduplicated_by_instance(self):
         fake_socket = FakeDiscoverySocket(response_count=2)
-
         endpoints = self.run_discovery(fake_socket)
-
-        self.assertEqual(
-            fake_socket.targets,
-            [
-                (bridge_discovery.DEFAULT_DISCOVERY_GROUP, 9876),
-                (bridge_discovery.LOCAL_DISCOVERY_HOST, 9876),
-            ],
-        )
+        self.assertEqual(fake_socket.targets, [
+            (bridge_discovery.DEFAULT_DISCOVERY_GROUP, 9876),
+            (bridge_discovery.LOCAL_DISCOVERY_HOST, 9876),
+        ])
         self.assertEqual([endpoint.pid for endpoint in endpoints], [4242])
         self.assertTrue(fake_socket.closed)
 
-    def test_loopback_still_discovers_when_multicast_send_fails(self):
+    def test_wildcard_bind_uses_remote_response_source(self):
         fake_socket = FakeDiscoverySocket(
-            fail_hosts={bridge_discovery.DEFAULT_DISCOVERY_GROUP}
+            response_overrides={"tcp_bind": "0.0.0.0"},
+            source_host="192.0.2.10",
         )
-
         endpoints = self.run_discovery(fake_socket)
+        self.assertEqual(len(endpoints), 1)
+        self.assertEqual(endpoints[0].response_host, "192.0.2.10")
+        self.assertEqual(endpoints[0].host, "192.0.2.10")
 
-        self.assertEqual([endpoint.tcp_port for endpoint in endpoints], [32123])
+    def test_loopback_still_discovers_when_multicast_send_fails(self):
+        fake_socket = FakeDiscoverySocket(fail_hosts={bridge_discovery.DEFAULT_DISCOVERY_GROUP})
+        self.assertEqual([endpoint.tcp_port for endpoint in self.run_discovery(fake_socket)], [32123])
+
+    def test_pid_reuse_with_two_instance_ids_stays_ambiguous(self):
+        fields = dict(
+            protocol_version=bridge_discovery.PROTOCOL_VERSION,
+            pid=4242,
+            project="TestProject",
+            project_path="C:/Projects/TestProject/TestProject.uproject",
+            engine_version="5.7.0",
+            tcp_bind="127.0.0.1",
+            tcp_port=32123,
+            token_fingerprint="",
+            capabilities=bridge_discovery.EXACT_CAPABILITIES,
+            response_host="127.0.0.1",
+        )
+        endpoints = [
+            bridge_discovery.Endpoint(instance_id="old-instance", **fields),
+            bridge_discovery.Endpoint(instance_id="new-instance", **fields),
+        ]
+        with self.assertRaises(bridge_discovery.DiscoveryError):
+            bridge_discovery.select(endpoints, project_filter="TestProject")
+
+    def test_malformed_datagrams_do_not_suppress_later_valid_response(self):
+        malformed = [
+            ("root", []),
+            b"\xff",
+            {"v": True},
+            {"protocol_version": 2.0},
+            {"pid": "bad"},
+            {"pid": 0},
+            {"pid": 2_147_483_648},
+            {"pid": float("nan")},
+            {"tcp_port": []},
+            {"tcp_port": 32123.5},
+            {"tcp_port": 0},
+            {"instance_id": "not-a-uuid"},
+            {"instance_id": "11111111-2222-4333-8444-55555555555Z"},
+            {"project_path": []},
+            {"tcp_bind": "not-an-ip"},
+            {"capabilities": "exact_exec"},
+            {"capabilities": list(bridge_discovery.EXACT_CAPABILITIES) + [7]},
+            {"capabilities": list(bridge_discovery.EXACT_CAPABILITIES) + ["exact_exec"]},
+            {"token_fingerprint": "NOT-HEX"},
+            {},
+        ]
+        endpoints = self.run_discovery(FakeDiscoverySocket(response_sequence=malformed))
+        self.assertEqual(len(endpoints), 1)
+        self.assertEqual(endpoints[0].instance_id, "11111111-2222-4333-8444-555555555555")
+
+    def test_minimum_capabilities_allow_unique_forward_compatible_extras(self):
+        capabilities = list(bridge_discovery.EXACT_CAPABILITIES) + ["exact_future_read"]
+        endpoints = self.run_discovery(FakeDiscoverySocket(
+            response_overrides={"capabilities": capabilities}
+        ))
+        self.assertEqual(endpoints[0].capabilities, tuple(capabilities))
+
+    def test_legacy_and_incomplete_v2_responses_are_ignored(self):
+        fake_socket = FakeDiscoverySocket(response_sequence=[
+            {"v": 1, "protocol_version": 1},
+            {"instance_id": ""},
+        ])
+        self.assertEqual(self.run_discovery(fake_socket), [])
 
     def test_discovery_raises_only_when_every_send_path_fails(self):
         fake_socket = FakeDiscoverySocket(
-            fail_hosts={
-                bridge_discovery.DEFAULT_DISCOVERY_GROUP,
-                bridge_discovery.LOCAL_DISCOVERY_HOST,
-            },
+            fail_hosts={bridge_discovery.DEFAULT_DISCOVERY_GROUP,
+                        bridge_discovery.LOCAL_DISCOVERY_HOST},
             response_count=0,
         )
-
         with self.assertRaises(OSError):
             self.run_discovery(fake_socket)
         self.assertTrue(fake_socket.closed)

--- a/tools/test_bridge_modal_client.py
+++ b/tools/test_bridge_modal_client.py
@@ -29,6 +29,22 @@ sys.modules[SPEC.name] = bridge
 SPEC.loader.exec_module(bridge)
 
 
+def sample_identity():
+    return bridge.Endpoint(
+        protocol_version=bridge.PROTOCOL_VERSION,
+        instance_id="11111111-2222-3333-4444-555555555555",
+        pid=4242,
+        project="TestProject",
+        project_path="C:/Projects/TestProject/TestProject.uproject",
+        engine_version="5.7.0",
+        tcp_bind="127.0.0.1",
+        tcp_port=12345,
+        token_fingerprint="",
+        capabilities=bridge.EXACT_CAPABILITIES,
+        response_host="127.0.0.1",
+    )
+
+
 def sample_modal() -> dict:
     return {
         "present": True,
@@ -74,7 +90,7 @@ class ModalClientTests(unittest.TestCase):
     def test_probe_uses_modal_bypass_command(self):
         response = {"success": True, "modal": sample_modal()}
         with mock.patch.object(bridge, "send_request", return_value=response) as send:
-            modal = bridge._probe_modal("127.0.0.1", 12345, None)
+            modal = bridge._probe_modal("127.0.0.1", 12345, None, sample_identity())
 
         self.assertEqual(modal["title"], "Message")
         payload = send.call_args.args[2]
@@ -100,7 +116,10 @@ class ModalClientTests(unittest.TestCase):
 
         with ExitStack() as stack:
             stack.enter_context(mock.patch.object(
-                bridge, "resolve_target", return_value=("127.0.0.1", 12345, None, None)
+                bridge, "resolve_target", return_value=(
+                    "127.0.0.1", 12345, None,
+                    "C:/Projects/TestProject/TestProject.uproject", sample_identity()
+                )
             ))
             stack.enter_context(mock.patch.object(
                 bridge, "send_request", return_value=server_timeout
@@ -116,7 +135,7 @@ class ModalClientTests(unittest.TestCase):
         self.assertEqual(exit_code, 1)
         self.assertTrue(rendered["blocked_by_modal"])
         self.assertEqual(rendered["modal"]["title"], "Message")
-        probe.assert_called_once_with("127.0.0.1", 12345, None)
+        probe.assert_called_once_with("127.0.0.1", 12345, None, sample_identity())
 
 
 if __name__ == "__main__":

--- a/tools/test_cancellable_work_contract.py
+++ b/tools/test_cancellable_work_contract.py
@@ -1,0 +1,84 @@
+"""验证 exec/modal 共用可取消 work 契约。 / Verify the shared cancellable-work contract for exec/modal."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_CPP = (
+    REPO_ROOT
+    / "Plugin"
+    / "UnrealBridge"
+    / "Source"
+    / "UnrealBridge"
+    / "Private"
+    / "UnrealBridgeServer.cpp"
+)
+WORK_HEADER = SERVER_CPP.with_name("UnrealBridgeCancellableWork.h")
+GUIDE = REPO_ROOT / "CLAUDE.md"
+
+
+class CancellableWorkSourceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = SERVER_CPP.read_text(encoding="utf-8")
+        cls.work = WORK_HEADER.read_text(encoding="utf-8")
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+
+    def test_state_machine_has_only_the_four_authoritative_states(self):
+        enum_body = self.work.split(
+            "enum class EUnrealBridgeWorkState", 1
+        )[1].split("};", 1)[0]
+        for state in ("Queued", "Running", "Cancelled", "Completed"):
+            self.assertEqual(enum_body.count(state), 1)
+
+    def test_exec_and_modal_use_the_same_work_primitive(self):
+        self.assertIn(
+            "TUnrealBridgeCancellableWork<FExecResult> Work;", self.server
+        )
+        self.assertIn(
+            "using FModalWork = "
+            "TUnrealBridgeCancellableWork<TSharedPtr<FJsonObject>>;",
+            self.server,
+        )
+        self.assertGreaterEqual(self.server.count("Pending->Work.TryCancel"), 2)
+        self.assertIn("Pending->TryCancel", self.server)
+        self.assertIn("Pending->Work.TryExecute", self.server)
+        self.assertIn("Pending->TryExecute", self.server)
+
+    def test_timeout_results_distinguish_cancelled_from_running(self):
+        self.assertIn("queued work cancelled before execution", self.server)
+        self.assertIn("work already started and outcome is unknown", self.server)
+        self.assertNotIn(
+            "Leave the promise alone — the ticker will still fulfill it later",
+            self.server,
+        )
+
+    def test_timeout_contract_is_documented_for_callers(self):
+        self.assertIn("cancelled before execution", self.guide)
+        self.assertIn("already started and outcome is unknown", self.guide)
+
+    def test_shutdown_closes_admission_and_drains_plugin_closures(self):
+        self.assertGreaterEqual(self.server.count("WorkAdmission->TryAdmit"), 2)
+        self.assertIn("WorkAdmission->Close();", self.server)
+        self.assertIn("WaitUntilTasksComplete", self.server)
+        self.assertIn("ProcessThreadUntilIdle", self.server)
+        self.assertNotIn("still active after 3s drain timeout", self.server)
+
+    def test_background_worker_owns_thread_safe_server_lifetime(self):
+        self.assertIn(
+            "TSharedRef<FUnrealBridgeServer, ESPMode::ThreadSafe> Self = AsShared();",
+            self.server,
+        )
+        self.assertIn("FFunctionGraphTask::CreateAndDispatchWhenReady", self.server)
+        self.assertNotIn("[this, ClientSocket, EndpointStr]", self.server)
+
+    def test_exec_ticker_skips_backlog_before_running_one_body(self):
+        self.assertIn("while (ExecQueue.Dequeue(Pending))", self.server)
+        self.assertIn("if (bExecuted)", self.server)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_endpoint_identity_contract.py
+++ b/tools/test_endpoint_identity_contract.py
@@ -1,0 +1,211 @@
+"""Deterministic client and source-contract tests for exact endpoint identity."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+MODULE_PATH = (Path(__file__).resolve().parents[1] / ".claude" / "skills" /
+               "unreal-bridge" / "scripts" / "bridge.py")
+SPEC = importlib.util.spec_from_file_location("unreal_bridge_cli_identity_tests", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load bridge CLI from {MODULE_PATH}")
+bridge = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bridge
+SPEC.loader.exec_module(bridge)
+
+
+def identity(instance_id="11111111-2222-4333-8444-555555555555", project_path=None):
+    return bridge.Endpoint(
+        protocol_version=bridge.PROTOCOL_VERSION,
+        instance_id=instance_id,
+        pid=4242,
+        project="TestProject",
+        project_path=(project_path
+                      if project_path is not None
+                      else "C:/Projects/TestProject/TestProject.uproject"),
+        engine_version="5.7.0",
+        tcp_bind="127.0.0.1",
+        tcp_port=32123,
+        token_fingerprint="",
+        capabilities=bridge.EXACT_CAPABILITIES,
+        response_host="127.0.0.1",
+    )
+
+
+def valid_response(ep=None):
+    ep = ep or identity()
+    return {
+        "success": True, "output": "pong", "error": "", "ready": True,
+        "protocol_version": ep.protocol_version,
+        "instance_id": ep.instance_id,
+        "pid": ep.pid,
+        "project_path": ep.project_path,
+    }
+
+
+class FakeTcpSocket:
+    def __init__(self, response=None, *, body=None, declared_length=None):
+        if body is None:
+            body = json.dumps(response).encode("utf-8")
+        length = len(body) if declared_length is None else declared_length
+        self.incoming = bytearray(struct.pack(">I", length) + body)
+        self.sent = bytearray()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def settimeout(self, _timeout):
+        pass
+
+    def connect(self, _endpoint):
+        pass
+
+    def sendall(self, data):
+        self.sent.extend(data)
+
+    def recv(self, size):
+        chunk = self.incoming[:size]
+        del self.incoming[:size]
+        return bytes(chunk)
+
+
+class EndpointIdentityTests(unittest.TestCase):
+    def send_with_socket(self, fake_socket, ep=None):
+        ep = ep or identity()
+        with mock.patch.object(bridge.socket, "socket", return_value=fake_socket):
+            return bridge.send_request("127.0.0.1", 32123,
+                                       {"command": "ping"}, 1, identity=ep)
+
+    def test_cpp_and_python_protocol_constants_match(self):
+        header = (Path(__file__).resolve().parents[1] / "Plugin" / "UnrealBridge" /
+                  "Source" / "UnrealBridge" / "Private" /
+                  "UnrealBridgeProtocol.h").read_text(encoding="utf-8")
+        self.assertIn(f"constexpr int32 Version = {bridge.PROTOCOL_VERSION};", header)
+        for capability in bridge.EXACT_CAPABILITIES:
+            self.assertIn(f'TEXT("{capability}")', header)
+
+    def test_production_handler_uses_exact_dispatcher_as_secondary_source_check(self):
+        source = (Path(__file__).resolve().parents[1] / "Plugin" / "UnrealBridge" /
+                  "Source" / "UnrealBridge" / "Private" /
+                  "UnrealBridgeServer.cpp").read_text(encoding="utf-8")
+        handler = source[source.index("void FUnrealBridgeServer::HandleClient"):
+                         source.index("// Python execution pipeline")]
+        dispatcher = handler.index("FUnrealBridgeExactRequestDispatcher::TryDispatch")
+        first_command_body = handler.index("EUnrealBridgeExactCommand::Ping")
+        self.assertLess(dispatcher, first_command_body)
+        self.assertIn("if (!bExactRequestValid)", handler[dispatcher:first_command_body])
+        self.assertIn("ResponseIdentity.AppendToResponse(Response)", handler)
+
+    def test_exec_wire_is_nested_and_preserves_exact_project_identity(self):
+        ep = identity(project_path="C:\\Projects\\Exact\\TestProject.uproject")
+        wire = bridge._build_exact_payload({
+            "id": "request-1", "script": "SIDE_EFFECT()", "timeout": 3,
+        }, ep)
+        self.assertEqual(wire["command"], "exact_exec")
+        self.assertNotIn("script", wire)
+        self.assertEqual(wire["request"]["script"], "SIDE_EFFECT()")
+        self.assertEqual(wire["expected"]["project_path"], ep.project_path)
+
+    def test_every_command_uses_exact_wire_form(self):
+        for command in ("ping", "gamethread_ping", "debug_resume",
+                        "modal_status", "modal_action"):
+            with self.subTest(command=command):
+                wire = bridge._build_exact_payload({"command": command}, identity())
+                self.assertEqual(wire["command"], f"exact_{command}")
+                self.assertEqual(wire["request"], {})
+
+    def test_correct_identity_round_trip_succeeds(self):
+        ep = identity()
+        sock = FakeTcpSocket(valid_response(ep))
+        result = self.send_with_socket(sock, ep)
+        self.assertTrue(result["success"])
+        sent_length = struct.unpack(">I", sock.sent[:4])[0]
+        sent = json.loads(sock.sent[4:4 + sent_length].decode("utf-8"))
+        self.assertEqual(sent["command"], "exact_ping")
+
+    def test_response_identity_requires_exact_string_and_integer_types(self):
+        ep = identity()
+        cases = [
+            {**valid_response(ep), "project_path": ep.project_path.lower()},
+            {**valid_response(ep), "project_path": ep.project_path.replace("/", "\\")},
+            {**valid_response(ep), "pid": float(ep.pid)},
+            {**valid_response(ep), "protocol_version": float(ep.protocol_version)},
+            {**valid_response(ep), "instance_id": None},
+        ]
+        for response in cases:
+            with self.subTest(response=response):
+                with self.assertRaises(bridge.EndpointIdentityError):
+                    bridge._verify_response_identity(response, ep)
+
+    def test_stale_instance_and_wrong_project_are_rejected(self):
+        stale = {**valid_response(), "instance_id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"}
+        wrong_project = {**valid_response(), "project_path": "C:/Other/Other.uproject"}
+        for response in (stale, wrong_project):
+            with self.assertRaises(bridge.EndpointIdentityError):
+                bridge._verify_response_identity(response, identity())
+
+    def test_legacy_response_and_missing_identity_fail_without_fallback(self):
+        with self.assertRaises(bridge.EndpointIdentityError):
+            bridge._verify_response_identity({"success": True, "output": "pong"}, identity())
+        with self.assertRaises(bridge.EndpointIdentityError):
+            bridge.send_request("127.0.0.1", 32123, {"command": "ping"}, 1)
+
+    def test_direct_endpoint_requires_and_preserves_inseparable_identity_tuple(self):
+        missing = SimpleNamespace(endpoint="127.0.0.1:32123", token=None,
+                                  instance_id=None, expected_project_path=None,
+                                  expected_pid=None)
+        with mock.patch.dict(bridge.os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit) as raised:
+                bridge.resolve_target(missing)
+        self.assertIn("direct legacy writes are not allowed", str(raised.exception))
+
+        exact_path = "C:\\Projects\\ExactCase\\TestProject.uproject"
+        args = SimpleNamespace(
+            endpoint="192.0.2.10:32123", token="secret",
+            instance_id=identity().instance_id,
+            expected_project_path=exact_path,
+            expected_pid=4242,
+        )
+        host, port, token, project_path, ep = bridge.resolve_target(args)
+        self.assertEqual((host, port, token), ("192.0.2.10", 32123, "secret"))
+        self.assertEqual(project_path, exact_path)
+        self.assertEqual(ep.project_path, exact_path)
+
+    def test_response_frame_length_boundaries(self):
+        for accepted in (1, bridge.MAX_RESPONSE_FRAME_BYTES):
+            bridge._validate_response_frame_length(accepted)
+        for rejected in (0, bridge.MAX_RESPONSE_FRAME_BYTES + 1, 0xFFFFFFFF):
+            with self.assertRaises(bridge.BridgeProtocolError):
+                bridge._validate_response_frame_length(rejected)
+
+    def test_oversized_frame_is_rejected_before_body_read(self):
+        sock = FakeTcpSocket(body=b"", declared_length=bridge.MAX_RESPONSE_FRAME_BYTES + 1)
+        with self.assertRaises(bridge.BridgeProtocolError):
+            self.send_with_socket(sock)
+        self.assertEqual(len(sock.incoming), 0)
+
+    def test_truncated_invalid_utf8_invalid_json_and_non_object_frames_fail(self):
+        cases = [
+            (FakeTcpSocket(body=b"{}", declared_length=20), ConnectionError),
+            (FakeTcpSocket(body=b"\xff"), bridge.BridgeProtocolError),
+            (FakeTcpSocket(body=b"{"), bridge.BridgeProtocolError),
+            (FakeTcpSocket(body=b"[]"), bridge.BridgeProtocolError),
+        ]
+        for sock, error_type in cases:
+            with self.subTest(error_type=error_type):
+                with self.assertRaises(error_type):
+                    self.send_with_socket(sock)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked PR:** this branch contains #6 (`e295e7f`) plus one identity commit (`bfe31d6`). The identity implementation depends on #6's shared work-admission/cancellation/shutdown lifecycle. After #6 merges, this branch will be rebased so this PR becomes identity-only.

## Summary

Introduce protocol v2 exact endpoint identity for discovery and every TCP command:

- Server-start UUID `instance_id`
- frozen `protocol_version + instance_id + PID + exact project_path`
- v2 UDP discovery with strict malformed-datagram isolation and minimum required capabilities
- six exact nested wire commands: exec, ping, GameThread ping, debug resume, modal status and modal action
- one production dispatcher that validates identity/request shape before command body/admission
- authoritative identity echoed in every response and rechecked by the client
- no legacy fallback; plugin and common client are deployed atomically

## Security / failure behavior

- legacy, alias, missing/malformed, wrong instance/PID/project and stale-response forms fail closed before side effects
- project identity is the exact case-sensitive wire string returned by discovery/startup on every OS
- protocol/PID numbers must be finite, positive, integral int32 JSON numbers
- direct mode requires the inseparable endpoint + instance UUID + PID + project path tuple
- response frames are bounded to 10 MiB and strictly validated for completeness, UTF-8, JSON and object root
- wildcard TCP advertisements use the UDP response source IP for remote discovery
- loopback remains the default; non-loopback bind requires token authentication and is explicitly network-reachable

## Validation

- Python discovery/modal/cancellation/identity/framing tests: 32/32 pass
- Python compile and diff checks: pass
- UE 5.6 BuildPlugin: 84/84 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 BuildPlugin: 84/84 build actions completed, `BUILD SUCCESSFUL`, exit 0
- UE 5.7 broad Automation `UnrealBridge.Server`: six tests, five clean successes plus the existing expected warning-bearing socket-shutdown success, zero failures/not-run, Queue Empty
- isolated UE 5.7 live session:
  - discovery + exact ping/GameThread ping/modal status/exec succeeded with identity echo
  - legacy, wrong-instance, wrong-project and case-mismatch write-marker requests returned structured rejection and created no marker
  - editor exited gracefully through an exact exec request

## Compatibility / remaining coverage

Protocol v2 intentionally rejects v1 rather than falling back. Built on UE 5.6 and 5.7; UE 5.3-5.5 and 5.8 were not locally available. macOS/Linux, a physical remote-machine wildcard-LAN run, forced real port reuse and a real Slate modal action remain untested.

Depends on #6: https://github.com/TornLux/UnrealBridge/pull/6
