### PR TITLE
feat(material): support parameter association identities

### DIFF
--- a/.claude/skills/unreal-bridge/references/bridge-material-api.md
+++ b/.claude/skills/unreal-bridge/references/bridge-material-api.md
@@ -19,7 +19,7 @@ info = unreal.UnrealBridgeMaterialLibrary.get_material_instance_parameters(
     '/Engine/EngineMaterials/Widget3DPassThrough_Opaque')
 print(f'{info.name} (parent: {info.parent_name})')
 for p in info.parameters:
-    print(f'  [{p.param_type}] {p.name} = {p.value}')
+    print(f'  [{p.param_type}] {p.name} [{p.association},{p.index}] = {p.value}')
 ```
 
 ### FBridgeMaterialInstanceInfo fields
@@ -36,8 +36,11 @@ for p in info.parameters:
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | str | Parameter name |
-| `param_type` | str | "Scalar" / "Vector" / "Texture" / "DoubleVector" / "RuntimeVirtualTexture" |
+| `param_type` | str | `"Scalar"` / `"Vector"` / `"Texture"` / `"DoubleVector"` / `"RuntimeVirtualTexture"` / `"StaticSwitch"` |
 | `value` | str | String representation of the value |
+| `association` | str | Stable complete-identity field: `"Global"` / `"LayerParameter"` / `"BlendParameter"` |
+| `index` | int | `-1` for Global; non-negative layer/blend slot index otherwise |
+| `override` | bool | Whether this instance directly overrides the exact parameter identity (all returned dynamic entries and returned static switches are direct overrides) |
 
 ---
 
@@ -290,7 +293,7 @@ for i, layer in enumerate(chain.layers):
 |-------|------|-------------|
 | `name` / `path` | str | This layer's asset |
 | `is_base_material` | bool | `True` for the final `UMaterial` leaf of the chain |
-| `override_parameters` | list[FBridgeMaterialParam] | Parameters *explicitly set on this layer*. Always empty for the base `UMaterial` (defaults for master parameters are reported by `get_material_info`, not here). Covers all 5 override tables: Scalar / Vector / DoubleVector / Texture / RuntimeVirtualTexture. |
+| `override_parameters` | list[FBridgeMaterialParam] | Parameters *explicitly set on this layer*. Always empty for the base `UMaterial` (defaults for master parameters are reported by `get_material_info`, not here). Covers all 6 override categories: Scalar / Vector / DoubleVector / Texture / RuntimeVirtualTexture / StaticSwitch. |
 
 ### Notes
 
@@ -1087,22 +1090,28 @@ All M6 calls work on **Material Instances** (`UMaterialInstanceConstant`). If yo
 
 ## set_mi_params(material_instance_path, params) -> FBridgeMIParamResult
 
-**M6-1.** Batch-write scalar / vector / texture / static-switch override values onto a Material Instance Constant. Each entry validates against the parent material — params that don't exist upstream are reported in `skipped` rather than silently failing.
+**M6-1.** Atomically batch-write scalar / vector / texture / static-switch overrides onto a Material Instance Constant. Identity is the complete `(name, association, index)` tuple. Omitting `association` and `index` preserves the original behavior and targets exactly `Global/-1`; it never broad-matches same-named layer or blend parameters.
+
+The complete batch is validated before mutation. If any selector, type, value, or texture path is invalid, nothing changes. Duplicate requests resolving to the same complete `(type, name, association, index)` identity reject the whole batch, including aliases such as `bool`/`StaticSwitch` and empty type/`Scalar`. Duplicate inputs report `Duplicate`; otherwise-valid inputs report `NotApplied` because the atomic batch was rejected.
+
+An input whose exact explicit override already has the requested value reports `Unchanged`: it is successful, is not counted in `applied`, and does not transact, notify, or dirty the MI. An all-`Unchanged` batch performs no mutation. A mixed batch uses one transaction and mutates only `Applied` entries, followed by one editor notification/dirty mark. Static-switch changes update the resolved entry in place (preserving `ExpressionGUID`) and update the static permutation once per changed batch. The call marks the package dirty but does **not** save or wait for shader compilation; use `get_material_shader_compile_status` if readiness matters.
 
 ```python
-def ps(name, type, value):
-    p = unreal.BridgeMIParamSet(); p.name = name; p.type = type; p.value = value
+def ps(name, type, value, association="Global", index=-1):
+    p = unreal.BridgeMIParamSet()
+    p.name, p.type, p.value = name, type, value
+    p.association, p.index = association, index
     return p
 
 r = unreal.UnrealBridgeMaterialLibrary.set_mi_params(
     "/Game/Materials/MI_Bronze_Scratched",
     [ps("Roughness", "Scalar", "0.65"),
-     ps("BaseColor", "Vector", "(R=0.78,G=0.45,B=0.2,A=1)"),
-     ps("WearMask",  "Texture", "/Game/Textures/T_Wear.T_Wear"),
-     ps("UseDetail", "StaticSwitch", "true")])
+     ps("Tint", "Vector", "(R=0.78,G=0.45,B=0.2,A=1)", "LayerParameter", 1),
+     ps("UseDetail", "StaticSwitch", "true", "BlendParameter", 0)])
 
-print(f"applied {r.applied}, skipped {len(r.skipped)}")
-for s in r.skipped: print(f"  {s}")
+print(f"applied {r.applied}, success={r.success}")
+for outcome in r.outcomes:
+    print(outcome.name, outcome.association, outcome.index, outcome.status, outcome.error)
 ```
 
 ### FBridgeMIParamSet fields
@@ -1112,24 +1121,32 @@ for s in r.skipped: print(f"  {s}")
 | `name` | str | Parameter name on the parent |
 | `type` | str | `"Scalar"` / `"Vector"` / `"Texture"` / `"StaticSwitch"` (aliases: `"bool"`, `"switch"`) |
 | `value` | str | ImportText-format: floats as `"0.5"`, colors as `"(R=,G=,B=,A=)"`, texture as full asset path, bool as `"true"`/`"false"` |
+| `association` | str | `"Global"` (default), `"LayerParameter"`, or `"BlendParameter"`; matching is case-insensitive and outcomes normalize valid values |
+| `index` | int | `-1` for Global (default); required non-negative slot for LayerParameter/BlendParameter |
 
 ### FBridgeMIParamResult fields
 
 | Field | Type | Description |
 |---|---|---|
-| `success` | bool | True only if every param applied |
-| `applied` | int | Count of params that wrote successfully |
-| `skipped` | list[str] | Diagnostic messages for failures ("not found on parent" / "vector unparseable" / etc.) |
+| `success` | bool | True when the whole atomic batch validates; empty and all-`Unchanged` batches succeed without a transaction |
+| `applied` | int | Number of entries actually changed; excludes `Unchanged`, and is `0` after any validation failure |
+| `skipped` | list[str] | Compatibility diagnostics; prefer `outcomes` for machine-readable handling |
+| `outcomes` | list[FBridgeMIParamOutcome] | One result per input, in input order |
 
-### UE 5.7 gotcha — ignore the engine's bool return
+### FBridgeMIParamOutcome fields
 
-`UMaterialEditingLibrary::SetMaterialInstanceScalarParameterValue` has a documented engine bug where `bResult = false` is returned unconditionally — the value *does* get applied via `SetScalarParameterValueEditorOnly`. This wrapper works around that by probing the parent first and always treating the setter call as advisory; clients don't see the raw bool.
+| Field | Type | Description |
+|---|---|---|
+| `name` / `type` / `association` / `index` | str / str / str / int | Echoed exact request identity (valid association spellings are normalized) |
+| `applied` | bool | True only when this entry was changed and committed; false for successful `Unchanged` entries |
+| `status` | str | `"Applied"`, `"Unchanged"`, `"Duplicate"`, `"NotFound"`, `"InvalidSelector"`, `"InvalidValue"`, `"InvalidType"`, `"NotApplied"`, or `"Error"` |
+| `error` | str | Empty for `Applied`/`Unchanged`; otherwise a diagnostic. `Duplicate` identifies every repeated typed complete identity, while `NotApplied` means another entry invalidated the atomic batch |
 
 ---
 
 ## set_mi_and_preview(mi_path, params, mesh, lighting, resolution, yaw, pitch, distance, out_png) -> bool
 
-**M6-2.** `set_mi_params` followed by `preview_material` in one atomic call. The MI is saved after applying (persist the override values), then the preview renders.
+**M6-2.** `set_mi_params` followed by `preview_material` in one call. Parameter application has the same exact-selector and atomic-validation behavior. If the atomic parameter batch fails, the function returns `False` without rendering the unchanged old state. A successful mutation marks the MI dirty but does not save it; preview rendering does not wait for static shader compilation.
 
 ```python
 ok = unreal.UnrealBridgeMaterialLibrary.set_mi_and_preview(
@@ -1190,19 +1207,19 @@ L.set_material_parameter_collection("/Game/MPC/MPC_Weather", [
 
 ## diff_mi_params(path_a, path_b) -> str
 
-**M6-5.** Text diff of MI override values. Line prefixes:
+**M6-5.** Text diff of MI override values. Every key is the complete `(Type, Name, Association, Index)` identity, so same-named Global, Layer, Blend, Scalar, Vector, and Texture entries cannot overwrite one another. Line prefixes:
 
-- `+ Type Name = value` — override in B that A lacks
-- `- Type Name = value` — override in A that B lacks
-- `~ Type Name: oldValue -> newValue` — same param, different value
+- `+ Type Name [Association,Index] = value` — exact override in B that A lacks
+- `- Type Name [Association,Index] = value` — exact override in A that B lacks
+- `~ Type Name [Association,Index]: oldValue -> newValue` — same exact override, different value
 - `(no override differences)` — identical overrides
 
 Walks Scalar / Vector / Texture tables. Does not walk parent chains — only each MI's own override table is compared.
 
 ```python
 print(L.diff_mi_params(mi_bronze_a, mi_bronze_b))
-# ~ Scalar Roughness: 0.5 -> 0.75
-# ~ Vector BaseColor: (R=1.0,G=0.2,B=0.2,A=1.0) -> (R=0.3,G=0.3,B=0.35,A=1.0)
+# ~ Scalar Roughness [Global,-1]: 0.5 -> 0.75
+# ~ Vector BaseColor [LayerParameter,1]: (R=1.0,G=0.2,B=0.2,A=1.0) -> (R=0.3,G=0.3,B=0.35,A=1.0)
 ```
 
 ---

--- a/.claude/skills/unreal-bridge/scripts/bridge_manifest.json
+++ b/.claude/skills/unreal-bridge/scripts/bridge_manifest.json
@@ -31,7 +31,7 @@
       "TIMER"
     ]
   },
-  "generated_at": "2026-08-16T23:54:12+00:00",
+  "generated_at": "2026-08-18T04:19:33+00:00",
   "libraries": {
     "UnrealBridgeAnimLibrary": {
       "functions": {
@@ -29292,7 +29292,7 @@
       }
     }
   },
-  "project_path": "D:/UB/ml2host/MaterialLayerTestHost.uproject",
+  "project_path": "D:/UB/mprhost/MaterialParameterReviewHost.uproject",
   "structs": {
     "BridgeAbilityCooldownInfo": [
       "ability_class_name",
@@ -30244,12 +30244,24 @@
       "lumen_reflections_enabled",
       "visualization_modes"
     ],
+    "BridgeMIParamOutcome": [
+      "applied",
+      "association",
+      "error",
+      "index",
+      "name",
+      "status",
+      "type"
+    ],
     "BridgeMIParamResult": [
       "applied",
+      "outcomes",
       "skipped",
       "success"
     ],
     "BridgeMIParamSet": [
+      "association",
+      "index",
       "name",
       "type",
       "value"
@@ -30457,7 +30469,10 @@
       "success"
     ],
     "BridgeMaterialParam": [
+      "association",
+      "index",
       "name",
+      "override",
       "param_type",
       "value"
     ],

--- a/Plugin/UnrealBridge/Content/Python/unreal_bridge.py
+++ b/Plugin/UnrealBridge/Content/Python/unreal_bridge.py
@@ -16,7 +16,7 @@ structural rather than mnemonic.
 
 import unreal
 
-_GENERATED_AT = '2026-08-16T23:54:12+00:00'
+_GENERATED_AT = '2026-08-18T04:19:33+00:00'
 _UE_VERSION = '5.7.4-51494982+++UE5+Release-5.7'
 
 class Anim:

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialParameterTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialParameterTests.cpp
@@ -1,0 +1,375 @@
+#include "Misc/AutomationTest.h"
+#include "Misc/EngineVersionComparison.h"
+
+#if WITH_DEV_AUTOMATION_TESTS && !UE_VERSION_OLDER_THAN(5, 7, 0)
+
+#include "Editor.h"
+#include "HAL/FileManager.h"
+#include "MaterialEditingLibrary.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionStaticSwitchParameter.h"
+#include "Materials/MaterialExpressionTextureSampleParameter2D.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "Materials/MaterialInstanceConstant.h"
+#include "Misc/Paths.h"
+#include "UnrealBridgeMaterialLibrary.h"
+#include "UnrealBridgeMaterialParameterHelpers.h"
+#include "UObject/Package.h"
+
+using namespace BridgeMaterialParameterHelpers;
+
+namespace UnrealBridgeMaterialParameterTests
+{
+	static FBridgeMIParamSet MakeRequest(
+		const TCHAR* Name,
+		const TCHAR* Type,
+		const TCHAR* Value,
+		const TCHAR* Association = TEXT("Global"),
+		int32 Index = INDEX_NONE)
+	{
+		FBridgeMIParamSet Request;
+		Request.Name = Name;
+		Request.Type = Type;
+		Request.Value = Value;
+		Request.Association = Association;
+		Request.Index = Index;
+		return Request;
+	}
+
+	/**
+	 * 真实瞬态材质夹具通过编辑器生产路径注册参数，并保留包以检查脏状态。
+	 * A real transient material fixture registers parameters through editor production paths and retains its package for dirty-state checks.
+	 */
+	struct FTransientMaterialFixture
+	{
+		UPackage* Package = nullptr;
+		UMaterial* Material = nullptr;
+		UMaterialInstanceConstant* Instance = nullptr;
+		FGuid StaticSwitchGuid;
+
+		FTransientMaterialFixture()
+		{
+			const FString Suffix = FGuid::NewGuid().ToString(EGuidFormats::Digits);
+			Package = CreatePackage(*FString::Printf(TEXT("/Temp/UnrealBridgeMaterialParameterTest_%s"), *Suffix));
+			Material = NewObject<UMaterial>(Package, *FString::Printf(TEXT("M_%s"), *Suffix), RF_Transient | RF_Transactional);
+
+			UMaterialExpressionScalarParameter* Scalar = CastChecked<UMaterialExpressionScalarParameter>(
+				UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionScalarParameter::StaticClass()));
+			Scalar->ParameterName = TEXT("ScalarParam");
+			Scalar->DefaultValue = 0.1f;
+
+			UMaterialExpressionVectorParameter* Vector = CastChecked<UMaterialExpressionVectorParameter>(
+				UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionVectorParameter::StaticClass()));
+			Vector->ParameterName = TEXT("VectorParam");
+			Vector->DefaultValue = FLinearColor::Black;
+
+			UMaterialExpressionTextureSampleParameter2D* Texture = CastChecked<UMaterialExpressionTextureSampleParameter2D>(
+				UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionTextureSampleParameter2D::StaticClass()));
+			Texture->ParameterName = TEXT("TextureParam");
+
+			UMaterialExpressionStaticSwitchParameter* StaticSwitch = CastChecked<UMaterialExpressionStaticSwitchParameter>(
+				UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionStaticSwitchParameter::StaticClass()));
+			StaticSwitch->ParameterName = TEXT("StaticSwitchParam");
+			StaticSwitch->DefaultValue = false;
+			StaticSwitch->ExpressionGUID = FGuid::NewGuid();
+			StaticSwitchGuid = StaticSwitch->ExpressionGUID;
+
+			Material->PostEditChange();
+			Instance = NewObject<UMaterialInstanceConstant>(Package, *FString::Printf(TEXT("MI_%s"), *Suffix), RF_Transient | RF_Transactional);
+			Instance->SetParentEditorOnly(Material);
+			Instance->PostEditChange();
+			Package->SetDirtyFlag(false);
+		}
+
+		FString InstancePath() const
+		{
+			return Instance->GetPathName();
+		}
+	};
+
+	static const FBridgeMaterialParam* FindReadParameter(
+		const FBridgeMaterialInstanceInfo& Info,
+		const TCHAR* Type,
+		const FMaterialParameterInfo& Identity)
+	{
+		return Info.Parameters.FindByPredicate([Type, &Identity](const FBridgeMaterialParam& Parameter)
+		{
+			return Parameter.ParamType == Type
+				&& Parameter.Name == Identity.Name.ToString()
+				&& Parameter.Association == AssociationToString(Identity.Association)
+				&& Parameter.Index == Identity.Index;
+		});
+	}
+
+	static void AddScalarOverride(
+		UMaterialInstanceConstant* Instance,
+		const FMaterialParameterInfo& Identity,
+		float Value)
+	{
+		FScalarParameterValue& Entry = Instance->ScalarParameterValues.AddDefaulted_GetRef();
+		Entry.ParameterInfo = Identity;
+		Entry.ParameterValue = Value;
+	}
+
+	static void AddVectorOverride(
+		UMaterialInstanceConstant* Instance,
+		const FMaterialParameterInfo& Identity,
+		const FLinearColor& Value)
+	{
+		FVectorParameterValue& Entry = Instance->VectorParameterValues.AddDefaulted_GetRef();
+		Entry.ParameterInfo = Identity;
+		Entry.ParameterValue = Value;
+	}
+}
+
+/**
+ * 使用纯参数身份验证同名参数不会跨 Global/Layer/Blend 关联匹配。
+ * Verify with parameter identities that duplicate names never match across Global/Layer/Blend associations.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeMaterialParameterIdentityTest,
+	"UnrealBridge.Material.Parameters.ExactAssociationIdentity",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeMaterialParameterIdentityTest::RunTest(const FString& Parameters)
+{
+	const FName DuplicateName(TEXT("Duplicate"));
+	const FMaterialParameterInfo Global(DuplicateName, EMaterialParameterAssociation::GlobalParameter, INDEX_NONE);
+	const FMaterialParameterInfo LayerOne(DuplicateName, EMaterialParameterAssociation::LayerParameter, 1);
+	const FMaterialParameterInfo BlendZero(DuplicateName, EMaterialParameterAssociation::BlendParameter, 0);
+	const TArray<FMaterialParameterInfo> Infos{Global, LayerOne, BlendZero};
+
+	FMaterialParameterInfo Parsed;
+	FString Error;
+	TestTrue(TEXT("Omitted association resolves to Global/-1"),
+		TryMakeParameterInfo(TEXT("Duplicate"), TEXT(""), INDEX_NONE, Parsed, Error));
+	TestTrue(TEXT("Omitted selector is exactly global"), Parsed == Global);
+	TestTrue(TEXT("Exact layer selector is found"), ContainsExactInfo(Infos, LayerOne));
+	TestFalse(TEXT("Missing layer index does not fall back to a duplicate name"),
+		ContainsExactInfo(Infos, FMaterialParameterInfo(DuplicateName, EMaterialParameterAssociation::LayerParameter, 2)));
+
+	Error.Reset();
+	TestFalse(TEXT("Global selector rejects a non-global index"),
+		TryMakeParameterInfo(TEXT("Duplicate"), TEXT("Global"), 0, Parsed, Error));
+	TestFalse(TEXT("Invalid selector reports an error"), Error.IsEmpty());
+	return true;
+}
+
+/**
+ * 差异与组合预览必须使用完整参数身份，并在原子设置失败时停止而不是渲染旧状态。
+ * Diff and combined preview must use complete parameter identity and stop after atomic-set failure instead of rendering stale state.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeMaterialParameterDiffAndPreviewFailureTest,
+	"UnrealBridge.Material.Parameters.DiffIdentityAndPreviewFailure",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeMaterialParameterDiffAndPreviewFailureTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeMaterialParameterTests;
+
+	FTransientMaterialFixture Fixture;
+	UMaterialInstanceConstant* DiffA = NewObject<UMaterialInstanceConstant>(
+		Fixture.Package, TEXT("MI_DiffA"), RF_Transient | RF_Transactional);
+	UMaterialInstanceConstant* DiffB = NewObject<UMaterialInstanceConstant>(
+		Fixture.Package, TEXT("MI_DiffB"), RF_Transient | RF_Transactional);
+	DiffA->SetParentEditorOnly(Fixture.Material);
+	DiffB->SetParentEditorOnly(Fixture.Material);
+
+	const FName AssociationName(TEXT("SameNameAcrossAssociations"));
+	const FMaterialParameterInfo Global(AssociationName, EMaterialParameterAssociation::GlobalParameter, INDEX_NONE);
+	const FMaterialParameterInfo LayerOne(AssociationName, EMaterialParameterAssociation::LayerParameter, 1);
+	const FMaterialParameterInfo BlendZero(AssociationName, EMaterialParameterAssociation::BlendParameter, 0);
+	AddScalarOverride(DiffA, Global, 1.0f);
+	AddScalarOverride(DiffA, LayerOne, 2.0f);
+	AddScalarOverride(DiffA, BlendZero, 3.0f);
+	AddScalarOverride(DiffB, Global, 1.0f);
+	AddScalarOverride(DiffB, LayerOne, 20.0f);
+	AddScalarOverride(DiffB, BlendZero, 3.0f);
+
+	const FMaterialParameterInfo CrossType(FName(TEXT("SameNameAcrossTypes")));
+	AddScalarOverride(DiffA, CrossType, 4.0f);
+	AddScalarOverride(DiffB, CrossType, 5.0f);
+	AddVectorOverride(DiffA, CrossType, FLinearColor::White);
+	AddVectorOverride(DiffB, CrossType, FLinearColor::White);
+
+	const FString Diff = UUnrealBridgeMaterialLibrary::DiffMIParams(DiffA->GetPathName(), DiffB->GetPathName());
+	TArray<FString> DiffLines;
+	Diff.ParseIntoArrayLines(DiffLines, false);
+	TestEqual(TEXT("Only the two exact changed identities are reported"), DiffLines.Num(), 2);
+	TestTrue(TEXT("Layer-scoped duplicate name remains independently visible"),
+		Diff.Contains(TEXT("~ Scalar SameNameAcrossAssociations [LayerParameter,1]:")));
+	TestTrue(TEXT("Scalar identity is not overwritten by a same-named vector"),
+		Diff.Contains(TEXT("~ Scalar SameNameAcrossTypes [Global,-1]:")));
+	TestFalse(TEXT("Equal global association is not falsely reported"),
+		Diff.Contains(TEXT("SameNameAcrossAssociations [Global,-1]")));
+	TestFalse(TEXT("Equal blend association is not falsely reported"),
+		Diff.Contains(TEXT("SameNameAcrossAssociations [BlendParameter,0]")));
+
+	int32 RenderCallCount = 0;
+	FBridgeMIParamResult FailedSet;
+	TestFalse(TEXT("Failed atomic set rejects the combined operation"),
+		SetMIAndPreviewAfterSuccessfulSet(
+			[&]() { return FailedSet; },
+			[&]() { ++RenderCallCount; return true; }));
+	TestEqual(TEXT("Failed atomic set never invokes the render operation"), RenderCallCount, 0);
+
+	FBridgeMIParamResult SuccessfulSet;
+	SuccessfulSet.bSuccess = true;
+	TestTrue(TEXT("Successful atomic set forwards the render result"),
+		SetMIAndPreviewAfterSuccessfulSet(
+			[&]() { return SuccessfulSet; },
+			[&]() { ++RenderCallCount; return true; }));
+	TestEqual(TEXT("Successful atomic set invokes rendering exactly once"), RenderCallCount, 1);
+
+	const FString PreviewPath = FPaths::Combine(
+		FPaths::ProjectIntermediateDir(),
+		FString::Printf(TEXT("UnrealBridgeRejectedPreview_%s.png"), *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+	IFileManager::Get().Delete(*PreviewPath, false, true, true);
+	Fixture.Package->SetDirtyFlag(false);
+	const bool bPreviewResult = UUnrealBridgeMaterialLibrary::SetMIAndPreview(
+		Fixture.InstancePath(),
+		{MakeRequest(TEXT("MissingScalar"), TEXT("Scalar"), TEXT("1.0"))},
+		TEXT("sphere"), TEXT("studio"), 32, 0.0f, 0.0f, 0.0f, PreviewPath);
+	TestFalse(TEXT("Combined preview fails when the atomic parameter batch fails"), bPreviewResult);
+	TestFalse(TEXT("Rejected parameter batch does not render a stale preview file"),
+		IFileManager::Get().FileExists(*PreviewPath));
+	TestFalse(TEXT("Rejected parameter batch does not dirty the material package"), Fixture.Package->IsDirty());
+	IFileManager::Get().Delete(*PreviewPath, false, true, true);
+	return true;
+}
+
+/**
+ * 在真实瞬态 UMaterial/UMaterialInstanceConstant 上覆盖读取、原子预检、幂等、静态排列和事务撤销/重做。
+ * Exercise readback, atomic preflight, idempotence, static permutations, and transaction undo/redo on real transient UMaterial/UMaterialInstanceConstant objects.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUnrealBridgeMaterialParameterProductionTest,
+	"UnrealBridge.Material.Parameters.ProductionSetReadAtomicityAndTransactions",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUnrealBridgeMaterialParameterProductionTest::RunTest(const FString& Parameters)
+{
+	using namespace UnrealBridgeMaterialParameterTests;
+
+	FTransientMaterialFixture Fixture;
+	const FMaterialParameterInfo ScalarInfo(FName(TEXT("ScalarParam")));
+	const FMaterialParameterInfo SwitchInfo(FName(TEXT("StaticSwitchParam")));
+
+	// 查询接口必须逐项保留真实覆盖表中的完整关联身份。
+	// The query API must preserve complete association identity from real override tables entry by entry.
+	const FName QueryName(TEXT("AssociationQueryOnly"));
+	for (const FMaterialParameterInfo& Info : {
+		FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::GlobalParameter, INDEX_NONE),
+		FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::LayerParameter, 1),
+		FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::BlendParameter, 0)})
+	{
+		FScalarParameterValue& Entry = Fixture.Instance->ScalarParameterValues.AddDefaulted_GetRef();
+		Entry.ParameterInfo = Info;
+		Entry.ParameterValue = static_cast<float>(Info.Index + 2);
+	}
+	FBridgeMaterialInstanceInfo Read = UUnrealBridgeMaterialLibrary::GetMaterialInstanceParameters(Fixture.InstancePath());
+	TestNotNull(TEXT("Global query identity is returned exactly"), FindReadParameter(Read, TEXT("Scalar"), FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::GlobalParameter, INDEX_NONE)));
+	TestNotNull(TEXT("Layer query identity is returned exactly"), FindReadParameter(Read, TEXT("Scalar"), FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::LayerParameter, 1)));
+	TestNotNull(TEXT("Blend query identity is returned exactly"), FindReadParameter(Read, TEXT("Scalar"), FMaterialParameterInfo(QueryName, EMaterialParameterAssociation::BlendParameter, 0)));
+
+	FBridgeMIParamResult Initial = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.25")),
+		MakeRequest(TEXT("VectorParam"), TEXT("Vector"), TEXT("(R=0.1,G=0.2,B=0.3,A=1.0)"))});
+	TestTrue(TEXT("Initial real-MI batch succeeds"), Initial.bSuccess);
+	TestEqual(TEXT("Initial batch applies both changes"), Initial.Applied, 2);
+	Read = UUnrealBridgeMaterialLibrary::GetMaterialInstanceParameters(Fixture.InstancePath());
+	const FBridgeMaterialParam* ScalarRead = FindReadParameter(Read, TEXT("Scalar"), ScalarInfo);
+	TestNotNull(TEXT("Changed scalar is readable through production query"), ScalarRead);
+	if (ScalarRead)
+	{
+		TestEqual(TEXT("Changed scalar readback is exact"), FCString::Atof(*ScalarRead->Value), 0.25f);
+	}
+
+	FBridgeMIParamResult Mixed = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.75")),
+		MakeRequest(TEXT("VectorParam"), TEXT("Vector"), TEXT("(R=0.1,G=0.2,B=0.3,A=1.0)"))});
+	TestTrue(TEXT("Mixed changed/unchanged batch succeeds"), Mixed.bSuccess);
+	TestEqual(TEXT("Mixed batch counts only the changed entry"), Mixed.Applied, 1);
+	TestEqual(TEXT("Changed mixed entry reports Applied"), Mixed.Outcomes[0].Status, FString(TEXT("Applied")));
+	TestEqual(TEXT("Idempotent mixed entry reports Unchanged"), Mixed.Outcomes[1].Status, FString(TEXT("Unchanged")));
+	TestFalse(TEXT("Unchanged mixed entry is not marked applied"), Mixed.Outcomes[1].bApplied);
+
+	Fixture.Package->SetDirtyFlag(false);
+	FBridgeMIParamResult Duplicate = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.9")),
+		MakeRequest(TEXT("ScalarParam"), TEXT(""), TEXT("0.8")),
+		MakeRequest(TEXT("VectorParam"), TEXT("Vector"), TEXT("(R=1,G=1,B=1,A=1)"))});
+	TestFalse(TEXT("Duplicate typed identity rejects the entire batch"), Duplicate.bSuccess);
+	TestEqual(TEXT("First duplicate is identified truthfully"), Duplicate.Outcomes[0].Status, FString(TEXT("Duplicate")));
+	TestEqual(TEXT("Alias duplicate is identified truthfully"), Duplicate.Outcomes[1].Status, FString(TEXT("Duplicate")));
+	TestEqual(TEXT("Otherwise-valid peer reports atomic NotApplied"), Duplicate.Outcomes[2].Status, FString(TEXT("NotApplied")));
+	TestFalse(TEXT("Duplicate rejection does not dirty the package"), Fixture.Package->IsDirty());
+	float ScalarValue = 0.0f;
+	TestTrue(TEXT("Scalar remains queryable after duplicate rejection"), Fixture.Instance->GetScalarParameterValue(ScalarInfo, ScalarValue));
+	TestEqual(TEXT("Duplicate rejection performs zero scalar mutation"), ScalarValue, 0.75f);
+
+	Fixture.Package->SetDirtyFlag(false);
+	AddExpectedError(
+		TEXT("LoadPackage: SkipPackage: /Game/DefinitelyMissing/T_DoesNotExist"),
+		EAutomationExpectedErrorFlags::Contains,
+		1);
+	AddExpectedError(
+		TEXT("Failed to find object 'Texture /Game/DefinitelyMissing/T_DoesNotExist.T_DoesNotExist'"),
+		EAutomationExpectedErrorFlags::Contains,
+		1);
+	FBridgeMIParamResult LateFailure = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.95")),
+		MakeRequest(TEXT("TextureParam"), TEXT("Texture"), TEXT("/Game/DefinitelyMissing/T_DoesNotExist.T_DoesNotExist"))});
+	TestFalse(TEXT("Late texture load failure rejects the batch"), LateFailure.bSuccess);
+	TestEqual(TEXT("Earlier valid entry reports NotApplied"), LateFailure.Outcomes[0].Status, FString(TEXT("NotApplied")));
+	TestEqual(TEXT("Texture load failure reports InvalidValue"), LateFailure.Outcomes[1].Status, FString(TEXT("InvalidValue")));
+	TestFalse(TEXT("Late failure does not dirty the package"), Fixture.Package->IsDirty());
+	Fixture.Instance->GetScalarParameterValue(ScalarInfo, ScalarValue);
+	TestEqual(TEXT("Late failure performs zero earlier mutation"), ScalarValue, 0.75f);
+
+	FStaticParameterSet BeforeStatic;
+	Fixture.Instance->GetStaticParameterValues(BeforeStatic);
+	FStaticSwitchParameter* BeforeSwitch = FindExactStaticSwitch(BeforeStatic, SwitchInfo);
+	TestNotNull(TEXT("Fixture exposes a real static switch"), BeforeSwitch);
+	const FGuid OriginalSwitchGuid = BeforeSwitch ? BeforeSwitch->ExpressionGUID : Fixture.StaticSwitchGuid;
+	FBridgeMIParamResult StaticResult = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("StaticSwitchParam"), TEXT("StaticSwitch"), TEXT("true"))});
+	TestTrue(TEXT("Static switch update succeeds"), StaticResult.bSuccess);
+	FStaticParameterSet AfterStatic;
+	Fixture.Instance->GetStaticParameterValues(AfterStatic);
+	FStaticSwitchParameter* AfterSwitch = FindExactStaticSwitch(AfterStatic, SwitchInfo);
+	TestNotNull(TEXT("Static switch remains after UpdateStaticPermutation"), AfterSwitch);
+	if (AfterSwitch)
+	{
+		TestTrue(TEXT("Static switch value and override are applied"), AfterSwitch->Value && AfterSwitch->bOverride);
+		TestEqual(TEXT("UpdateStaticPermutation preserves ExpressionGUID"), AfterSwitch->ExpressionGUID, OriginalSwitchGuid);
+	}
+
+	FBridgeMIParamResult TransactionalChange = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.9"))});
+	TestTrue(TEXT("Transactional scalar change succeeds"), TransactionalChange.bSuccess);
+	Fixture.Package->SetDirtyFlag(false);
+	FBridgeMIParamResult NoOp = UUnrealBridgeMaterialLibrary::SetMIParams(Fixture.InstancePath(), {
+		MakeRequest(TEXT("ScalarParam"), TEXT("Scalar"), TEXT("0.9"))});
+	TestTrue(TEXT("Idempotent request succeeds"), NoOp.bSuccess);
+	TestEqual(TEXT("Idempotent request applies zero entries"), NoOp.Applied, 0);
+	TestEqual(TEXT("Idempotent request reports Unchanged"), NoOp.Outcomes[0].Status, FString(TEXT("Unchanged")));
+	TestFalse(TEXT("Idempotent request does not dirty the package"), Fixture.Package->IsDirty());
+
+	TestNotNull(TEXT("Editor transaction subsystem is available"), GEditor);
+	if (GEditor)
+	{
+		TestTrue(TEXT("Undo succeeds and skips any no-op transaction"), GEditor->UndoTransaction());
+		Fixture.Instance->GetScalarParameterValue(ScalarInfo, ScalarValue);
+		TestEqual(TEXT("Undo restores the preceding changed value"), ScalarValue, 0.75f);
+		TestTrue(TEXT("Redo succeeds"), GEditor->RedoTransaction());
+		Fixture.Instance->GetScalarParameterValue(ScalarInfo, ScalarValue);
+		TestEqual(TEXT("Redo reapplies the changed value"), ScalarValue, 0.9f);
+	}
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS && UE 5.7+

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeMaterialLibrary.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeMaterialLibrary.cpp
@@ -5,6 +5,8 @@
 
 #if !UE_VERSION_OLDER_THAN(5, 7, 0)
 
+#include "UnrealBridgeMaterialParameterHelpers.h"
+
 #include "Materials/Material.h"
 #include "Materials/MaterialInstance.h"
 #include "Materials/MaterialInterface.h"
@@ -89,9 +91,50 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "AssetRegistry/ARFilter.h"
+#include "String/LexFromString.h"
 
 namespace BridgeMaterialImpl
 {
+	using namespace BridgeMaterialParameterHelpers;
+
+	/**
+	 * 将引擎参数身份复制到稳定的反射字段，避免同名的全局、层和混合参数失去区别。
+	 * Copy engine parameter identity into stable reflected fields so same-named global, layer, and blend parameters remain distinct.
+	 */
+	static void SetMaterialParamIdentity(
+		FBridgeMaterialParam& Param,
+		const FMaterialParameterInfo& Info,
+		bool bOverride = true)
+	{
+		Param.Name = Info.Name.ToString();
+		Param.Association = AssociationToString(Info.Association);
+		Param.Index = Info.Index;
+		Param.bOverride = bOverride;
+	}
+
+	static void AppendStaticSwitchOverrides(
+		const UMaterialInstance* MI,
+		TArray<FBridgeMaterialParam>& OutParameters)
+	{
+		FStaticParameterSet StaticParameters;
+		// 引擎读取接口缺少 const 限定但不会修改实例；仅在这个只读边界移除 const。
+		// The engine read API is not const-qualified but does not mutate the instance; remove const only at this read boundary.
+		const_cast<UMaterialInstance*>(MI)->GetStaticParameterValues(StaticParameters);
+		for (const FStaticSwitchParameter& P : StaticParameters.StaticSwitchParameters)
+		{
+			if (!P.bOverride)
+			{
+				continue;
+			}
+
+			FBridgeMaterialParam Param;
+			SetMaterialParamIdentity(Param, P.ParameterInfo, P.bOverride);
+			Param.ParamType = TEXT("StaticSwitch");
+			Param.Value = P.Value ? TEXT("True") : TEXT("False");
+			OutParameters.Add(MoveTemp(Param));
+		}
+	}
+
 	static FString DomainToString(EMaterialDomain Domain)
 	{
 		switch (Domain)
@@ -391,6 +434,8 @@ namespace BridgeMaterialImpl
 FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstanceParameters(
 	const FString& MaterialPath)
 {
+	using namespace BridgeMaterialImpl;
+
 	FBridgeMaterialInstanceInfo Result;
 
 	UMaterialInstance* MI = LoadObject<UMaterialInstance>(nullptr, *MaterialPath);
@@ -411,7 +456,7 @@ FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstancePar
 	for (const FScalarParameterValue& P : MI->ScalarParameterValues)
 	{
 		FBridgeMaterialParam Param;
-		Param.Name = P.ParameterInfo.Name.ToString();
+		SetMaterialParamIdentity(Param, P.ParameterInfo);
 		Param.ParamType = TEXT("Scalar");
 		Param.Value = FString::SanitizeFloat(P.ParameterValue);
 		Result.Parameters.Add(Param);
@@ -420,7 +465,7 @@ FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstancePar
 	for (const FVectorParameterValue& P : MI->VectorParameterValues)
 	{
 		FBridgeMaterialParam Param;
-		Param.Name = P.ParameterInfo.Name.ToString();
+		SetMaterialParamIdentity(Param, P.ParameterInfo);
 		Param.ParamType = TEXT("Vector");
 		Param.Value = FString::Printf(TEXT("(R=%.4f,G=%.4f,B=%.4f,A=%.4f)"),
 			P.ParameterValue.R, P.ParameterValue.G, P.ParameterValue.B, P.ParameterValue.A);
@@ -430,7 +475,7 @@ FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstancePar
 	for (const FDoubleVectorParameterValue& P : MI->DoubleVectorParameterValues)
 	{
 		FBridgeMaterialParam Param;
-		Param.Name = P.ParameterInfo.Name.ToString();
+		SetMaterialParamIdentity(Param, P.ParameterInfo);
 		Param.ParamType = TEXT("DoubleVector");
 		Param.Value = P.ParameterValue.ToString();
 		Result.Parameters.Add(Param);
@@ -439,7 +484,7 @@ FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstancePar
 	for (const FTextureParameterValue& P : MI->TextureParameterValues)
 	{
 		FBridgeMaterialParam Param;
-		Param.Name = P.ParameterInfo.Name.ToString();
+		SetMaterialParamIdentity(Param, P.ParameterInfo);
 		Param.ParamType = TEXT("Texture");
 		Param.Value = P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None");
 		Result.Parameters.Add(Param);
@@ -448,12 +493,13 @@ FBridgeMaterialInstanceInfo UUnrealBridgeMaterialLibrary::GetMaterialInstancePar
 	for (const FRuntimeVirtualTextureParameterValue& P : MI->RuntimeVirtualTextureParameterValues)
 	{
 		FBridgeMaterialParam Param;
-		Param.Name = P.ParameterInfo.Name.ToString();
+		SetMaterialParamIdentity(Param, P.ParameterInfo);
 		Param.ParamType = TEXT("RuntimeVirtualTexture");
 		Param.Value = P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None");
 		Result.Parameters.Add(Param);
 	}
 
+	AppendStaticSwitchOverrides(MI, Result.Parameters);
 	return Result;
 }
 
@@ -1073,7 +1119,7 @@ namespace BridgeMaterialImpl
 		for (const FScalarParameterValue& P : MI->ScalarParameterValues)
 		{
 			FBridgeMaterialParam Param;
-			Param.Name = P.ParameterInfo.Name.ToString();
+			SetMaterialParamIdentity(Param, P.ParameterInfo);
 			Param.ParamType = TEXT("Scalar");
 			Param.Value = FString::SanitizeFloat(P.ParameterValue);
 			Layer.OverrideParameters.Add(MoveTemp(Param));
@@ -1081,7 +1127,7 @@ namespace BridgeMaterialImpl
 		for (const FVectorParameterValue& P : MI->VectorParameterValues)
 		{
 			FBridgeMaterialParam Param;
-			Param.Name = P.ParameterInfo.Name.ToString();
+			SetMaterialParamIdentity(Param, P.ParameterInfo);
 			Param.ParamType = TEXT("Vector");
 			Param.Value = FString::Printf(TEXT("(R=%.4f,G=%.4f,B=%.4f,A=%.4f)"),
 				P.ParameterValue.R, P.ParameterValue.G, P.ParameterValue.B, P.ParameterValue.A);
@@ -1090,7 +1136,7 @@ namespace BridgeMaterialImpl
 		for (const FDoubleVectorParameterValue& P : MI->DoubleVectorParameterValues)
 		{
 			FBridgeMaterialParam Param;
-			Param.Name = P.ParameterInfo.Name.ToString();
+			SetMaterialParamIdentity(Param, P.ParameterInfo);
 			Param.ParamType = TEXT("DoubleVector");
 			Param.Value = P.ParameterValue.ToString();
 			Layer.OverrideParameters.Add(MoveTemp(Param));
@@ -1098,7 +1144,7 @@ namespace BridgeMaterialImpl
 		for (const FTextureParameterValue& P : MI->TextureParameterValues)
 		{
 			FBridgeMaterialParam Param;
-			Param.Name = P.ParameterInfo.Name.ToString();
+			SetMaterialParamIdentity(Param, P.ParameterInfo);
 			Param.ParamType = TEXT("Texture");
 			Param.Value = P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None");
 			Layer.OverrideParameters.Add(MoveTemp(Param));
@@ -1106,11 +1152,12 @@ namespace BridgeMaterialImpl
 		for (const FRuntimeVirtualTextureParameterValue& P : MI->RuntimeVirtualTextureParameterValues)
 		{
 			FBridgeMaterialParam Param;
-			Param.Name = P.ParameterInfo.Name.ToString();
+			SetMaterialParamIdentity(Param, P.ParameterInfo);
 			Param.ParamType = TEXT("RuntimeVirtualTexture");
 			Param.Value = P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None");
 			Layer.OverrideParameters.Add(MoveTemp(Param));
 		}
+		AppendStaticSwitchOverrides(MI, Layer.OverrideParameters);
 	}
 }
 
@@ -3691,98 +3738,83 @@ FBridgeShaderSnippet UUnrealBridgeMaterialLibrary::GetSharedSnippet(const FStrin
 
 namespace BridgeMaterialImpl
 {
-	/**
-	 * Apply one FBridgeMIParamSet to a UMaterialInstanceConstant. Returns true on success.
-	 * Dispatches on Type — each handler parses Value with the format documented on the
-	 * FBridgeMIParamSet struct.
-	 */
-	static bool ApplyMIParam(
-		UMaterialInstanceConstant* MIC,
-		const FBridgeMIParamSet& P,
-		FString& OutError)
+	using namespace BridgeMaterialParameterHelpers;
+
+	enum class EMIParamKind : uint8
 	{
-		if (!MIC)
-		{
-			OutError = TEXT("null MI");
-			return false;
-		}
+		Scalar,
+		Vector,
+		Texture,
+		StaticSwitch
+	};
 
-		const FName ParamName(*P.Name);
-		const FString TypeLower = P.Type.ToLower();
+	/**
+	 * 已验证的请求持有解析后的值，确保事务开始后不会再发生加载或解析失败。
+	 * A validated request owns its parsed value so no loading or parsing can fail after the transaction starts.
+	 */
+	struct FValidatedMIParam
+	{
+		EMIParamKind Kind = EMIParamKind::Scalar;
+		FMaterialParameterInfo Info;
+		float Scalar = 0.0f;
+		FLinearColor Vector = FLinearColor::Black;
+		UTexture* Texture = nullptr;
+		bool bSelectorAndTypeValid = false;
+		bool bDuplicate = false;
+		bool bChanged = false;
+	};
 
-		// NOTE: UE 5.7's UMaterialEditingLibrary::SetMaterialInstance*ParameterValue
-		// functions have a stub `bool bResult = false` that is never updated — the return
-		// value is effectively meaningless (always false). The setter *does* mutate the MI
-		// via SetScalarParameterValueEditorOnly. We rely on that side effect and verify
-		// parameter existence up-front via a GetScalarParameterValue probe.
-		const FMaterialParameterInfo Info(ParamName);
-
+	static bool TryParseMIParamKind(const FString& Type, EMIParamKind& OutKind)
+	{
+		const FString TypeLower = Type.ToLower();
 		if (TypeLower == TEXT("scalar") || TypeLower.IsEmpty())
 		{
-			float Probe;
-			if (!MIC->GetScalarParameterValue(Info, Probe))
-			{
-				OutError = FString::Printf(TEXT("scalar param '%s' not found on parent"), *P.Name);
-				return false;
-			}
-			const float V = FCString::Atof(*P.Value);
-			UMaterialEditingLibrary::SetMaterialInstanceScalarParameterValue(MIC, ParamName, V);
+			OutKind = EMIParamKind::Scalar;
 			return true;
 		}
 		if (TypeLower == TEXT("vector"))
 		{
-			FLinearColor Probe;
-			if (!MIC->GetVectorParameterValue(Info, Probe))
-			{
-				OutError = FString::Printf(TEXT("vector param '%s' not found on parent"), *P.Name);
-				return false;
-			}
-			FLinearColor V(FLinearColor::Black);
-			if (!V.InitFromString(P.Value))
-			{
-				OutError = FString::Printf(TEXT("vector value '%s' not parseable — expected (R=,G=,B=,A=)"), *P.Value);
-				return false;
-			}
-			UMaterialEditingLibrary::SetMaterialInstanceVectorParameterValue(MIC, ParamName, V);
+			OutKind = EMIParamKind::Vector;
 			return true;
 		}
 		if (TypeLower == TEXT("texture"))
 		{
-			UTexture* ProbeTex = nullptr;
-			if (!MIC->GetTextureParameterValue(Info, ProbeTex))
-			{
-				OutError = FString::Printf(TEXT("texture param '%s' not found on parent"), *P.Name);
-				return false;
-			}
-			UTexture* Tex = nullptr;
-			if (!P.Value.IsEmpty() && P.Value.ToLower() != TEXT("none"))
-			{
-				Tex = LoadObject<UTexture>(nullptr, *P.Value);
-				if (!Tex)
-				{
-					OutError = FString::Printf(TEXT("texture '%s' failed to load"), *P.Value);
-					return false;
-				}
-			}
-			UMaterialEditingLibrary::SetMaterialInstanceTextureParameterValue(MIC, ParamName, Tex);
+			OutKind = EMIParamKind::Texture;
 			return true;
 		}
 		if (TypeLower == TEXT("staticswitch") || TypeLower == TEXT("switch") || TypeLower == TEXT("bool"))
 		{
-			bool ProbeBool;
-			FGuid ProbeGuid;
-			if (!MIC->GetStaticSwitchParameterValue(Info, ProbeBool, ProbeGuid))
-			{
-				OutError = FString::Printf(TEXT("static-switch param '%s' not found on parent"), *P.Name);
-				return false;
-			}
-			const FString Lower = P.Value.ToLower();
-			const bool V = (Lower == TEXT("true") || Lower == TEXT("1") || Lower == TEXT("yes"));
-			UMaterialEditingLibrary::SetMaterialInstanceStaticSwitchParameterValue(MIC, ParamName, V);
+			OutKind = EMIParamKind::StaticSwitch;
 			return true;
 		}
+		return false;
+	}
 
-		OutError = FString::Printf(TEXT("unknown param type '%s' — expected Scalar/Vector/Texture/StaticSwitch"), *P.Type);
+	static void SetOutcomeFailure(
+		FBridgeMIParamOutcome& Outcome,
+		const FString& Status,
+		const FString& Error)
+	{
+		Outcome.Status = Status;
+		Outcome.Error = Error;
+	}
+
+	static bool ParseStaticSwitchValue(const FString& Text, bool& OutValue)
+	{
+		if (Text.Equals(TEXT("true"), ESearchCase::IgnoreCase)
+			|| Text == TEXT("1")
+			|| Text.Equals(TEXT("yes"), ESearchCase::IgnoreCase))
+		{
+			OutValue = true;
+			return true;
+		}
+		if (Text.Equals(TEXT("false"), ESearchCase::IgnoreCase)
+			|| Text == TEXT("0")
+			|| Text.Equals(TEXT("no"), ESearchCase::IgnoreCase))
+		{
+			OutValue = false;
+			return true;
+		}
 		return false;
 	}
 }
@@ -3792,33 +3824,277 @@ FBridgeMIParamResult UUnrealBridgeMaterialLibrary::SetMIParams(
 	const TArray<FBridgeMIParamSet>& Params)
 {
 	using namespace BridgeMaterialImpl;
+	using namespace BridgeMaterialParameterHelpers;
 
 	FBridgeMIParamResult Result;
+	Result.Outcomes.Reserve(Params.Num());
+	for (const FBridgeMIParamSet& P : Params)
+	{
+		FBridgeMIParamOutcome& Outcome = Result.Outcomes.AddDefaulted_GetRef();
+		Outcome.Name = P.Name;
+		Outcome.Type = P.Type;
+		Outcome.Association = P.Association.IsEmpty() ? TEXT("Global") : P.Association;
+		Outcome.Index = P.Index;
+	}
 
 	UMaterialInstanceConstant* MIC = LoadObject<UMaterialInstanceConstant>(nullptr, *MaterialInstancePath);
 	if (!MIC)
 	{
-		Result.Skipped.Add(FString::Printf(TEXT("could not load MI '%s'"), *MaterialInstancePath));
+		const FString Error = FString::Printf(TEXT("could not load MI '%s'"), *MaterialInstancePath);
+		Result.Skipped.Add(Error);
+		for (FBridgeMIParamOutcome& Outcome : Result.Outcomes)
+		{
+			SetOutcomeFailure(Outcome, TEXT("Error"), Error);
+		}
 		return Result;
 	}
 
-	for (const FBridgeMIParamSet& P : Params)
+	TArray<FMaterialParameterInfo> ScalarInfos;
+	TArray<FMaterialParameterInfo> VectorInfos;
+	TArray<FMaterialParameterInfo> TextureInfos;
+	TArray<FGuid> ParameterIds;
+	MIC->GetAllParameterInfoOfType(EMaterialParameterType::Scalar, ScalarInfos, ParameterIds);
+	ParameterIds.Reset();
+	MIC->GetAllParameterInfoOfType(EMaterialParameterType::Vector, VectorInfos, ParameterIds);
+	ParameterIds.Reset();
+	MIC->GetAllParameterInfoOfType(EMaterialParameterType::Texture, TextureInfos, ParameterIds);
+
+	FStaticParameterSet StaticParameters;
+	MIC->GetStaticParameterValues(StaticParameters);
+	TArray<FValidatedMIParam> Validated;
+	Validated.SetNum(Params.Num());
+	bool bValidationFailed = false;
+
+	// 第一遍只规范化身份和类型，以便在任何值加载或对象变更前拒绝整批重复目标。
+	// The first pass only normalizes identity and type so duplicate batch targets are rejected before value loading or object mutation.
+	for (int32 ParamIndex = 0; ParamIndex < Params.Num(); ++ParamIndex)
 	{
-		FString Err;
-		if (ApplyMIParam(MIC, P, Err))
+		const FBridgeMIParamSet& P = Params[ParamIndex];
+		FBridgeMIParamOutcome& Outcome = Result.Outcomes[ParamIndex];
+		FValidatedMIParam& Candidate = Validated[ParamIndex];
+		FString Error;
+		if (!TryMakeParameterInfo(P.Name, P.Association, P.Index, Candidate.Info, Error))
 		{
-			++Result.Applied;
+			SetOutcomeFailure(Outcome, TEXT("InvalidSelector"), Error);
+			bValidationFailed = true;
+			continue;
 		}
-		else
+		Outcome.Association = AssociationToString(Candidate.Info.Association);
+		if (!TryParseMIParamKind(P.Type, Candidate.Kind))
 		{
-			Result.Skipped.Add(FString::Printf(TEXT("%s = %s: %s"), *P.Name, *P.Value, *Err));
+			SetOutcomeFailure(Outcome, TEXT("InvalidType"), FString::Printf(TEXT("unknown param type '%s' — expected Scalar/Vector/Texture/StaticSwitch"), *P.Type));
+			bValidationFailed = true;
+			continue;
+		}
+		Candidate.bSelectorAndTypeValid = true;
+	}
+
+	for (int32 FirstIndex = 0; FirstIndex < Validated.Num(); ++FirstIndex)
+	{
+		if (!Validated[FirstIndex].bSelectorAndTypeValid)
+		{
+			continue;
+		}
+		for (int32 SecondIndex = FirstIndex + 1; SecondIndex < Validated.Num(); ++SecondIndex)
+		{
+			if (Validated[SecondIndex].bSelectorAndTypeValid
+				&& Validated[FirstIndex].Kind == Validated[SecondIndex].Kind
+				&& Validated[FirstIndex].Info == Validated[SecondIndex].Info)
+			{
+				Validated[FirstIndex].bDuplicate = true;
+				Validated[SecondIndex].bDuplicate = true;
+			}
+		}
+	}
+	for (int32 ParamIndex = 0; ParamIndex < Validated.Num(); ++ParamIndex)
+	{
+		if (Validated[ParamIndex].bDuplicate)
+		{
+			SetOutcomeFailure(Result.Outcomes[ParamIndex], TEXT("Duplicate"),
+				TEXT("duplicate parameter type and exact selector in the same batch"));
+			bValidationFailed = true;
 		}
 	}
 
+	// 第二遍解析值并判断是否真的改变显式覆盖；这里只修改静态参数集副本。
+	// The second pass parses values and detects real override changes; only the static-parameter copy is mutated here.
+	for (int32 ParamIndex = 0; ParamIndex < Params.Num(); ++ParamIndex)
+	{
+		const FBridgeMIParamSet& P = Params[ParamIndex];
+		FBridgeMIParamOutcome& Outcome = Result.Outcomes[ParamIndex];
+		FValidatedMIParam& Candidate = Validated[ParamIndex];
+		if (!Candidate.bSelectorAndTypeValid || Candidate.bDuplicate)
+		{
+			continue;
+		}
+
+		switch (Candidate.Kind)
+		{
+			case EMIParamKind::Scalar:
+			{
+				if (!ContainsExactInfo(ScalarInfos, Candidate.Info))
+				{
+					SetOutcomeFailure(Outcome, TEXT("NotFound"), TEXT("exact scalar selector not found on parent"));
+					bValidationFailed = true;
+					continue;
+				}
+				if (!LexTryParseString(Candidate.Scalar, *P.Value))
+				{
+					SetOutcomeFailure(Outcome, TEXT("InvalidValue"), FString::Printf(TEXT("scalar value '%s' is not parseable"), *P.Value));
+					bValidationFailed = true;
+					continue;
+				}
+				const FScalarParameterValue* Existing = MIC->ScalarParameterValues.FindByPredicate([&Candidate](const FScalarParameterValue& Value)
+				{
+					return Value.ParameterInfo == Candidate.Info;
+				});
+				Candidate.bChanged = !Existing || Existing->ParameterValue != Candidate.Scalar;
+				break;
+			}
+			case EMIParamKind::Vector:
+			{
+				if (!ContainsExactInfo(VectorInfos, Candidate.Info))
+				{
+					SetOutcomeFailure(Outcome, TEXT("NotFound"), TEXT("exact vector selector not found on parent"));
+					bValidationFailed = true;
+					continue;
+				}
+				if (!Candidate.Vector.InitFromString(P.Value))
+				{
+					SetOutcomeFailure(Outcome, TEXT("InvalidValue"), FString::Printf(TEXT("vector value '%s' is not parseable; expected (R=,G=,B=,A=)"), *P.Value));
+					bValidationFailed = true;
+					continue;
+				}
+				const FVectorParameterValue* Existing = MIC->VectorParameterValues.FindByPredicate([&Candidate](const FVectorParameterValue& Value)
+				{
+					return Value.ParameterInfo == Candidate.Info;
+				});
+				Candidate.bChanged = !Existing || Existing->ParameterValue != Candidate.Vector;
+				break;
+			}
+			case EMIParamKind::Texture:
+			{
+				if (!ContainsExactInfo(TextureInfos, Candidate.Info))
+				{
+					SetOutcomeFailure(Outcome, TEXT("NotFound"), TEXT("exact texture selector not found on parent"));
+					bValidationFailed = true;
+					continue;
+				}
+				if (!P.Value.IsEmpty() && !P.Value.Equals(TEXT("none"), ESearchCase::IgnoreCase))
+				{
+					Candidate.Texture = LoadObject<UTexture>(nullptr, *P.Value);
+					if (!Candidate.Texture)
+					{
+						SetOutcomeFailure(Outcome, TEXT("InvalidValue"), FString::Printf(TEXT("texture '%s' failed to load"), *P.Value));
+						bValidationFailed = true;
+						continue;
+					}
+				}
+				const FTextureParameterValue* Existing = MIC->TextureParameterValues.FindByPredicate([&Candidate](const FTextureParameterValue& Value)
+				{
+					return Value.ParameterInfo == Candidate.Info;
+				});
+				Candidate.bChanged = !Existing || Existing->ParameterValue != Candidate.Texture;
+				break;
+			}
+			case EMIParamKind::StaticSwitch:
+			{
+				FStaticSwitchParameter* Switch = FindExactStaticSwitch(StaticParameters, Candidate.Info);
+				if (!Switch)
+				{
+					SetOutcomeFailure(Outcome, TEXT("NotFound"), TEXT("exact static-switch selector not found on parent"));
+					bValidationFailed = true;
+					continue;
+				}
+				bool bValue = false;
+				if (!ParseStaticSwitchValue(P.Value, bValue))
+				{
+					SetOutcomeFailure(Outcome, TEXT("InvalidValue"), FString::Printf(TEXT("static-switch value '%s' is not parseable"), *P.Value));
+					bValidationFailed = true;
+					continue;
+				}
+				Candidate.bChanged = !Switch->bOverride || Switch->Value != bValue;
+				if (Candidate.bChanged)
+				{
+					// 保留引擎提供的 ExpressionGUID，仅改变显式覆盖值。
+					// Preserve the engine-provided ExpressionGUID while changing only the explicit override value.
+					Switch->Value = bValue;
+					Switch->bOverride = true;
+				}
+				break;
+			}
+		}
+		Outcome.Status = Candidate.bChanged ? TEXT("Validated") : TEXT("Unchanged");
+	}
+
+	if (bValidationFailed)
+	{
+		for (int32 ParamIndex = 0; ParamIndex < Result.Outcomes.Num(); ++ParamIndex)
+		{
+			FBridgeMIParamOutcome& Outcome = Result.Outcomes[ParamIndex];
+			if (Outcome.Status == TEXT("Validated") || Outcome.Status == TEXT("Unchanged"))
+			{
+				SetOutcomeFailure(Outcome, TEXT("NotApplied"), TEXT("batch validation failed; no parameters were changed"));
+			}
+			if (!Outcome.Error.IsEmpty())
+			{
+				Result.Skipped.Add(FString::Printf(TEXT("%s [%s,%d] = %s: %s"),
+					*Outcome.Name, *Outcome.Association, Outcome.Index, *Params[ParamIndex].Value, *Outcome.Error));
+			}
+		}
+		return Result;
+	}
+
+	int32 ChangedCount = 0;
+	bool bHasStaticChanges = false;
+	for (const FValidatedMIParam& Candidate : Validated)
+	{
+		ChangedCount += Candidate.bChanged ? 1 : 0;
+		bHasStaticChanges |= Candidate.bChanged && Candidate.Kind == EMIParamKind::StaticSwitch;
+	}
+	if (ChangedCount == 0)
+	{
+		Result.bSuccess = true;
+		return Result;
+	}
+
+	const FScopedTransaction Transaction(NSLOCTEXT("UnrealBridge", "SetMIParams", "Set material instance parameters"));
+	MIC->Modify();
+	for (int32 ParamIndex = 0; ParamIndex < Validated.Num(); ++ParamIndex)
+	{
+		const FValidatedMIParam& P = Validated[ParamIndex];
+		if (!P.bChanged)
+		{
+			continue;
+		}
+		switch (P.Kind)
+		{
+			case EMIParamKind::Scalar:
+				MIC->SetScalarParameterValueEditorOnly(P.Info, P.Scalar);
+				break;
+			case EMIParamKind::Vector:
+				MIC->SetVectorParameterValueEditorOnly(P.Info, P.Vector);
+				break;
+			case EMIParamKind::Texture:
+				MIC->SetTextureParameterValueEditorOnly(P.Info, P.Texture);
+				break;
+			case EMIParamKind::StaticSwitch:
+				break;
+		}
+		FBridgeMIParamOutcome& Outcome = Result.Outcomes[ParamIndex];
+		Outcome.bApplied = true;
+		Outcome.Status = TEXT("Applied");
+		Outcome.Error.Reset();
+	}
+	if (bHasStaticChanges)
+	{
+		MIC->UpdateStaticPermutation(StaticParameters);
+	}
 	MIC->PostEditChange();
 	MIC->MarkPackageDirty();
 
-	Result.bSuccess = Result.Skipped.Num() == 0;
+	Result.Applied = ChangedCount;
+	Result.bSuccess = true;
 	return Result;
 }
 
@@ -3835,16 +4111,18 @@ bool UUnrealBridgeMaterialLibrary::SetMIAndPreview(
 	float CameraDistance,
 	const FString& OutPngPath)
 {
-	FBridgeMIParamResult PR = SetMIParams(MaterialInstancePath, Params);
-	if (!PR.bSuccess)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("UnrealBridge: SetMIAndPreview skipped %d params — rendering anyway"), PR.Skipped.Num());
-	}
-
-	return BridgeMaterialImpl::RenderMaterialPreview(
-		MaterialInstancePath, Mesh, Lighting, Resolution,
-		CameraYawDeg, CameraPitchDeg, CameraDistance,
-		OutPngPath, /*bShaderComplexity=*/ false);
+	return BridgeMaterialParameterHelpers::SetMIAndPreviewAfterSuccessfulSet(
+		[&]()
+		{
+			return SetMIParams(MaterialInstancePath, Params);
+		},
+		[&]()
+		{
+			return BridgeMaterialImpl::RenderMaterialPreview(
+				MaterialInstancePath, Mesh, Lighting, Resolution,
+				CameraYawDeg, CameraPitchDeg, CameraDistance,
+				OutPngPath, /*bShaderComplexity=*/ false);
+		});
 }
 
 // ─── M6-3: sweep one param over a list of values ──────────────────
@@ -4155,61 +4433,96 @@ FBridgeMIParamResult UUnrealBridgeMaterialLibrary::SetMaterialParameterCollectio
 
 // ─── M6-5: diff two MI parameter sets ─────────────────────────────
 
+namespace BridgeMaterialImpl
+{
+	/**
+	 * 材质实例差异键使用类型和完整引擎参数身份，避免同名跨类型、层或混合槽互相覆盖。
+	 * Material-instance diff keys use type plus complete engine identity so names cannot collide across types, layers, or blend slots.
+	 */
+	struct FMIParameterDiffIdentity
+	{
+		FName Type;
+		FMaterialParameterInfo ParameterInfo;
+
+		bool operator==(const FMIParameterDiffIdentity& Other) const
+		{
+			return Type.IsEqual(Other.Type) && ParameterInfo == Other.ParameterInfo;
+		}
+
+		friend uint32 GetTypeHash(const FMIParameterDiffIdentity& Identity)
+		{
+			return HashCombine(GetTypeHash(Identity.Type), GetTypeHash(Identity.ParameterInfo));
+		}
+	};
+
+	static FString FormatMIParameterDiffIdentity(const FMIParameterDiffIdentity& Identity)
+	{
+		return FString::Printf(TEXT("%s %s [%s,%d]"),
+			*Identity.Type.ToString(),
+			*Identity.ParameterInfo.Name.ToString(),
+			*AssociationToString(Identity.ParameterInfo.Association),
+			Identity.ParameterInfo.Index);
+	}
+}
+
 FString UUnrealBridgeMaterialLibrary::DiffMIParams(
 	const FString& PathA,
 	const FString& PathB)
 {
+	using namespace BridgeMaterialImpl;
+
 	UMaterialInstance* A = LoadObject<UMaterialInstance>(nullptr, *PathA);
 	UMaterialInstance* B = LoadObject<UMaterialInstance>(nullptr, *PathB);
 	if (!A) return FString::Printf(TEXT("diff error: could not load A '%s'"), *PathA);
 	if (!B) return FString::Printf(TEXT("diff error: could not load B '%s'"), *PathB);
 
-	struct FEntry { FString Type; FString Value; };
-
-	auto Collect = [](UMaterialInstance* MI) -> TMap<FString, FEntry>
+	auto Collect = [](UMaterialInstance* MI) -> TMap<FMIParameterDiffIdentity, FString>
 	{
-		TMap<FString, FEntry> Out;
+		TMap<FMIParameterDiffIdentity, FString> Out;
 		for (const FScalarParameterValue& P : MI->ScalarParameterValues)
 		{
-			Out.Add(P.ParameterInfo.Name.ToString(), {TEXT("Scalar"), FString::SanitizeFloat(P.ParameterValue)});
+			Out.Add({FName(TEXT("Scalar")), P.ParameterInfo}, FString::SanitizeFloat(P.ParameterValue));
 		}
 		for (const FVectorParameterValue& P : MI->VectorParameterValues)
 		{
-			Out.Add(P.ParameterInfo.Name.ToString(), {TEXT("Vector"),
+			Out.Add({FName(TEXT("Vector")), P.ParameterInfo},
 				FString::Printf(TEXT("(R=%.4f,G=%.4f,B=%.4f,A=%.4f)"),
-					P.ParameterValue.R, P.ParameterValue.G, P.ParameterValue.B, P.ParameterValue.A)});
+					P.ParameterValue.R, P.ParameterValue.G, P.ParameterValue.B, P.ParameterValue.A));
 		}
 		for (const FTextureParameterValue& P : MI->TextureParameterValues)
 		{
-			Out.Add(P.ParameterInfo.Name.ToString(), {TEXT("Texture"),
-				P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None")});
+			Out.Add({FName(TEXT("Texture")), P.ParameterInfo},
+				P.ParameterValue ? P.ParameterValue->GetPathName() : TEXT("None"));
 		}
 		return Out;
 	};
 
-	TMap<FString, FEntry> MapA = Collect(A);
-	TMap<FString, FEntry> MapB = Collect(B);
+	const TMap<FMIParameterDiffIdentity, FString> MapA = Collect(A);
+	const TMap<FMIParameterDiffIdentity, FString> MapB = Collect(B);
 
 	TArray<FString> Lines;
-	// Added in B
-	for (const TPair<FString, FEntry>& KV : MapB)
+	// B 中新增的完整参数身份。 / Complete parameter identities added in B.
+	for (const TPair<FMIParameterDiffIdentity, FString>& Pair : MapB)
 	{
-		if (!MapA.Contains(KV.Key))
+		if (!MapA.Contains(Pair.Key))
 		{
-			Lines.Add(FString::Printf(TEXT("+ %s %s = %s"), *KV.Value.Type, *KV.Key, *KV.Value.Value));
+			Lines.Add(FString::Printf(TEXT("+ %s = %s"),
+				*FormatMIParameterDiffIdentity(Pair.Key), *Pair.Value));
 		}
 	}
-	// Removed / changed
-	for (const TPair<FString, FEntry>& KV : MapA)
+	// B 中删除或改变的完整参数身份。 / Complete parameter identities removed from or changed in B.
+	for (const TPair<FMIParameterDiffIdentity, FString>& Pair : MapA)
 	{
-		if (!MapB.Contains(KV.Key))
+		const FString* ValueB = MapB.Find(Pair.Key);
+		if (!ValueB)
 		{
-			Lines.Add(FString::Printf(TEXT("- %s %s = %s"), *KV.Value.Type, *KV.Key, *KV.Value.Value));
+			Lines.Add(FString::Printf(TEXT("- %s = %s"),
+				*FormatMIParameterDiffIdentity(Pair.Key), *Pair.Value));
 		}
-		else if (MapB[KV.Key].Value != KV.Value.Value)
+		else if (*ValueB != Pair.Value)
 		{
-			Lines.Add(FString::Printf(TEXT("~ %s %s: %s -> %s"),
-				*KV.Value.Type, *KV.Key, *KV.Value.Value, *MapB[KV.Key].Value));
+			Lines.Add(FString::Printf(TEXT("~ %s: %s -> %s"),
+				*FormatMIParameterDiffIdentity(Pair.Key), *Pair.Value, **ValueB));
 		}
 	}
 

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeMaterialParameterHelpers.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/UnrealBridgeMaterialParameterHelpers.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MaterialTypes.h"
+#include "StaticParameterSet.h"
+
+/**
+ * 材质参数选择器的内部转换与精确匹配工具；完整身份始终由名称、关联和索引共同组成。
+ * Internal conversion and exact-match helpers for material selectors; identity always includes name, association, and index.
+ */
+namespace BridgeMaterialParameterHelpers
+{
+	inline FString AssociationToString(EMaterialParameterAssociation Association)
+	{
+		switch (Association)
+		{
+			case EMaterialParameterAssociation::GlobalParameter: return TEXT("Global");
+			case EMaterialParameterAssociation::LayerParameter: return TEXT("LayerParameter");
+			case EMaterialParameterAssociation::BlendParameter: return TEXT("BlendParameter");
+			default: return TEXT("Unknown");
+		}
+	}
+
+	inline bool TryMakeParameterInfo(
+		const FString& Name,
+		const FString& Association,
+		int32 Index,
+		FMaterialParameterInfo& OutInfo,
+		FString& OutError)
+	{
+		const FString Selector = Association.IsEmpty() ? TEXT("Global") : Association;
+		EMaterialParameterAssociation ParsedAssociation;
+		if (Selector.Equals(TEXT("Global"), ESearchCase::IgnoreCase))
+		{
+			ParsedAssociation = EMaterialParameterAssociation::GlobalParameter;
+			if (Index != INDEX_NONE)
+			{
+				OutError = TEXT("Global association requires index -1");
+				return false;
+			}
+		}
+		else if (Selector.Equals(TEXT("LayerParameter"), ESearchCase::IgnoreCase))
+		{
+			ParsedAssociation = EMaterialParameterAssociation::LayerParameter;
+			if (Index < 0)
+			{
+				OutError = TEXT("LayerParameter association requires a non-negative index");
+				return false;
+			}
+		}
+		else if (Selector.Equals(TEXT("BlendParameter"), ESearchCase::IgnoreCase))
+		{
+			ParsedAssociation = EMaterialParameterAssociation::BlendParameter;
+			if (Index < 0)
+			{
+				OutError = TEXT("BlendParameter association requires a non-negative index");
+				return false;
+			}
+		}
+		else
+		{
+			OutError = FString::Printf(TEXT("unknown association '%s' — expected Global/LayerParameter/BlendParameter"), *Association);
+			return false;
+		}
+
+		if (Name.IsEmpty())
+		{
+			OutError = TEXT("parameter name is empty");
+			return false;
+		}
+
+		OutInfo = FMaterialParameterInfo(FName(*Name), ParsedAssociation, Index);
+		return true;
+	}
+
+	inline bool ContainsExactInfo(
+		const TArray<FMaterialParameterInfo>& Infos,
+		const FMaterialParameterInfo& Wanted)
+	{
+		return Infos.ContainsByPredicate([&Wanted](const FMaterialParameterInfo& Candidate)
+		{
+			return Candidate == Wanted;
+		});
+	}
+
+	inline FStaticSwitchParameter* FindExactStaticSwitch(
+		FStaticParameterSet& Parameters,
+		const FMaterialParameterInfo& Wanted)
+	{
+		return Parameters.StaticSwitchParameters.FindByPredicate([&Wanted](const FStaticSwitchParameter& Candidate)
+		{
+			return Candidate.ParameterInfo == Wanted;
+		});
+	}
+
+	/**
+	 * 组合操作只在原子参数批次成功后进入渲染；模板让测试以调用计数器验证该顺序，而无需真实渲染。
+	 * The combined operation renders only after the atomic parameter batch succeeds; the template lets tests verify ordering with call counters and no real render.
+	 */
+	template <typename SetOperationType, typename RenderOperationType>
+	bool SetMIAndPreviewAfterSuccessfulSet(
+		SetOperationType&& SetOperation,
+		RenderOperationType&& RenderOperation)
+	{
+		const auto ParamResult = Forward<SetOperationType>(SetOperation)();
+		if (!ParamResult.bSuccess)
+		{
+			return false;
+		}
+		return Forward<RenderOperationType>(RenderOperation)();
+	}
+}

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeMaterialLibrary.h
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Public/UnrealBridgeMaterialLibrary.h
@@ -4,22 +4,35 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "UnrealBridgeMaterialLibrary.generated.h"
 
-/** A material parameter with its value. */
+/** 材质实例上一个具有完整身份和值的参数覆盖。 / A parameter override on a material instance with its complete identity and value. */
 USTRUCT(BlueprintType)
 struct FBridgeMaterialParam
 {
 	GENERATED_BODY()
 
+	/** 参数名称。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	FString Name;
 
-	/** "Scalar", "Vector", "Texture", "DoubleVector", etc. */
+	/** 参数类型："Scalar"、"Vector"、"Texture"、"DoubleVector" 等。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	FString ParamType;
 
-	/** String representation of the value */
+	/** 参数值的字符串表示。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	FString Value;
+
+	/** 参数关联："Global"、"LayerParameter" 或 "BlendParameter"。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Association = TEXT("Global");
+
+	/** 关联槽索引；Global 固定为 -1，LayerParameter/BlendParameter 为非负槽索引。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	int32 Index = -1;
+
+	/** 此条目是否为当前实例直接提供的覆盖。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	bool bOverride = true;
 };
 
 /** Overview of a Material Instance. */
@@ -892,45 +905,92 @@ struct FBridgeMaterialGraphOpResult
 	int32 FailedAtIndex = -1;
 };
 
-/** One MI parameter override (for set_mi_params / MPC setter). */
+/** 一个材质实例参数覆盖请求；省略选择器时精确指向 Global/-1。 / One MI parameter override request; an omitted selector targets exactly Global/-1. */
 USTRUCT(BlueprintType)
 struct FBridgeMIParamSet
 {
 	GENERATED_BODY()
 
+	/** 参数名称。 */
 	UPROPERTY(BlueprintReadWrite, Category = "UnrealBridge|Material")
 	FString Name;
 
-	/** "Scalar" / "Vector" / "Texture" / "StaticSwitch" / "Collection" (MPC scalar auto-detect). */
+	/** 参数类型：MI 调用接受 "Scalar"、"Vector"、"Texture"、"StaticSwitch"；MPC 调用仅接受 "Scalar" 或 "Vector"。 */
 	UPROPERTY(BlueprintReadWrite, Category = "UnrealBridge|Material")
 	FString Type;
 
 	/**
-	 * ImportText-format value:
-	 *   Scalar        "0.5"
-	 *   Vector        "(R=1,G=0,B=0,A=1)"
-	 *   Texture       "/Game/Textures/T_Base.T_Base"
-	 *   StaticSwitch  "true" / "false"
+	 * ImportText 格式参数值：Scalar 为 "0.5"，Vector 为 "(R=1,G=0,B=0,A=1)"，
+	 * Texture 为完整资产路径，StaticSwitch 为 "true" 或 "false"。
 	 */
 	UPROPERTY(BlueprintReadWrite, Category = "UnrealBridge|Material")
 	FString Value;
+
+	/** 精确关联选择器；空字符串兼容为 "Global"。 */
+	UPROPERTY(BlueprintReadWrite, Category = "UnrealBridge|Material")
+	FString Association = TEXT("Global");
+
+	/** 精确关联槽索引；Global 必须为 -1，LayerParameter/BlendParameter 必须为非负值。 */
+	UPROPERTY(BlueprintReadWrite, Category = "UnrealBridge|Material")
+	int32 Index = -1;
 };
 
-/** Result of set_mi_params. */
+/** 单个 set_mi_params 请求的结构化结果。 / Structured outcome for one set_mi_params request. */
+USTRUCT(BlueprintType)
+struct FBridgeMIParamOutcome
+{
+	GENERATED_BODY()
+
+	/** 请求的参数名称。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Name;
+
+	/** 请求的参数类型。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Type;
+
+	/** 规范化后的请求关联；非法值保持原文。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Association;
+
+	/** 请求的精确槽索引。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	int32 Index = -1;
+
+	/** 此请求是否在本次调用中实际写入；"Unchanged" 为 false。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	bool bApplied = false;
+
+	/** 稳定状态："Applied"、"Unchanged"、"Duplicate"、"NotFound"、"InvalidSelector"、"InvalidValue"、"InvalidType"、"NotApplied" 或 "Error"。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Status;
+
+	/** 失败原因；成功时为空。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	FString Error;
+};
+
+/** set_mi_params 的批处理结果。 / Batch result of set_mi_params. */
 USTRUCT(BlueprintType)
 struct FBridgeMIParamResult
 {
 	GENERATED_BODY()
 
+	/** 整批验证成功时为 true；全部为 Unchanged 的无操作批次也成功。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	bool bSuccess = false;
 
+	/** 本次实际写入的请求数量；Unchanged 和验证失败的原子批次不计入。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	int32 Applied = 0;
 
-	/** Per-failed-param diagnostic messages. */
+	/** 兼容旧客户端的失败诊断文本。 */
 	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
 	TArray<FString> Skipped;
+
+	/** 按输入顺序返回的结构化结果；MI 批处理始终与输入等长。 */
+	UPROPERTY(BlueprintReadOnly, Category = "UnrealBridge|Material")
+	TArray<FBridgeMIParamOutcome> Outcomes;
 };
 
 /** Metadata for an HLSL snippet shipped in BridgeSnippets.ush (M2.5). */
@@ -1008,8 +1068,11 @@ class UNREALBRIDGE_API UUnrealBridgeMaterialLibrary : public UBlueprintFunctionL
 public:
 
 	/**
-	 * Get all parameter overrides on a Material Instance.
-	 * Returns scalar, vector, texture, and double vector parameters.
+	 * 获取材质实例上显式设置的全部参数覆盖。
+	 * Get every explicitly set parameter override on a Material Instance.
+	 *
+	 * 返回 Scalar、Vector、DoubleVector、Texture、RuntimeVirtualTexture 与 StaticSwitch 参数。
+	 * Returns Scalar, Vector, DoubleVector, Texture, RuntimeVirtualTexture, and StaticSwitch parameters.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Material")
 	static FBridgeMaterialInstanceInfo GetMaterialInstanceParameters(const FString& MaterialPath);
@@ -1462,10 +1525,10 @@ public:
 	static FBridgeShaderSnippet GetSharedSnippet(const FString& Name);
 
 	/**
-	 * M6-1: Write a batch of parameter overrides onto a Material Instance (or MPC).
-	 * Single dispatch covers scalar / vector / texture / static-switch by Type string.
-	 * Each entry is independent — a failed param doesn't abort the rest; failures are
-	 * reported in the Skipped array with reason text.
+	 * M6-1：以完整的 Name/Association/Index 身份原子写入材质实例参数批次。
+	 * M6-1: Atomically write a Material Instance batch using complete Name/Association/Index identity.
+	 * 整批在单个事务和任何变更前完成验证；重复的类型化完整身份会拒绝整批。相同值返回 Unchanged，且不会创建事务、通知或脏标记。
+	 * The whole batch is validated before one transaction and any mutation; duplicate typed complete identities reject the batch. Equal values return Unchanged without a transaction, notification, or dirty mark.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Material")
 	static FBridgeMIParamResult SetMIParams(
@@ -1473,9 +1536,10 @@ public:
 		const TArray<FBridgeMIParamSet>& Params);
 
 	/**
-	 * M6-2: Set MI parameters + render in one atomic call. The inverse of the usual
-	 * "tweak, then render, then tweak again" round-trip. Saves the MI after applying
-	 * so changes persist; use a disposable MI if you want non-destructive sweep.
+	 * M6-2：先以精确选择器原子设置 MI 参数，成功后才渲染预览；设置失败时返回 false 且不渲染旧状态。
+	 * M6-2: Atomically set exact MI selectors and render only after success; a failed set returns false without rendering stale state.
+	 * 成功写入仅标记包为脏，不保存也不等待着色器编译。
+	 * A successful write only dirties the package; it does not save or wait for shader compilation.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Material")
 	static bool SetMIAndPreview(
@@ -1526,11 +1590,10 @@ public:
 		const TArray<FBridgeMIParamSet>& Params);
 
 	/**
-	 * M6-5: Diff two MIs' override values. Text report formatted like:
-	 *   + Scalar Roughness = 0.35     (set in B, absent in A)
-	 *   - Vector Tint = (R=1,...)      (set in A, absent in B)
-	 *   ~ Scalar Metallic: 0.5 -> 0.8  (different value)
-	 * Parent chains are not walked — only each MI's own overrides are compared.
+	 * M6-5：按 Type/Name/Association/Index 完整身份比较两个 MI 自身的 Scalar、Vector、Texture 覆盖值。
+	 * M6-5: Compare two MIs' own Scalar, Vector, and Texture overrides by complete Type/Name/Association/Index identity.
+	 * 文本格式示例：`~ Scalar Metallic [LayerParameter,1]: 0.5 -> 0.8`；不遍历父链。
+	 * Example: `~ Scalar Metallic [LayerParameter,1]: 0.5 -> 0.8`; parent chains are not walked.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "UnrealBridge|Material")
 	static FString DiffMIParams(


### PR DESCRIPTION
## Summary

Material Instance overrides can share a name across global, layer, and blend scopes. This change makes the complete Unreal parameter identity explicit and keeps batch mutation atomic.

## Behavior

- Query results expose `Association`, `Index`, and `bOverride`, including direct static-switch overrides.
- Set requests resolve `(type, name, association, index)` exactly; omitted association/default index means `Global/-1` only.
- The whole batch is validated before mutation, including texture loads and duplicate typed selectors.
- Per-input outcomes distinguish `Applied`, `Unchanged`, `Duplicate`, `InvalidValue`, and atomic `NotApplied` cases.
- Unchanged-only calls do not transact, notify, or dirty the package; mixed batches write only changed entries.
- Static-switch updates preserve the existing expression GUID.

## Verification

- `tools/gen_version_stubs.py --check`: 440 stubs / 14 targets
- UE 5.6 BuildPlugin: 81/81 actions, success
- UE 5.7 BuildPlugin: 81/81 actions, success
- UE 5.7 Automation `UnrealBridge.Material.Parameters`: 2/2 clean success
- Manifest/wrapper regenerated from the rebuilt UE 5.7 plugin: 26 libraries / 1382 functions
- Independent final review: P0/P1/P2 = 0/0/0

## Compatibility

Validated locally on UE 5.6 and 5.7 Win64. UE 5.3-5.5, 5.8, macOS, and Linux were not available locally.
