### PR TITLE
chore: harden host builds and automation isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ __pycache__/
 tools/engines.local.json
 tools/build_engines/
 build_matrix_report.md
+
+# Unreal Engine artifacts generated when a host project builds the plugin
+/Plugin/*/Binaries/
+/Plugin/*/Intermediate/
+/Plugin/*/Saved/


### PR DESCRIPTION
## Summary
- ignore standard Unreal-generated `Binaries`, `Intermediate`, and `Saved` directories beneath plugin packages
- isolate the three automation tests that exercise global Editor Undo/Redo so transient fixtures cannot leak stale transaction records into later tests
- keep product/runtime code unchanged

## Why
### Host build artifacts
When UnrealBridge is discovered through a host project's `AdditionalPluginDirectories`, UHT writes generated headers under `Plugin/UnrealBridge/Intermediate`. Without an ignore rule, a clean source checkout becomes dirty after the first host-project build, and conservative submodule updaters must stop.

### Automation transaction ownership
In a full Oneiria Editor automation run, `UnrealBridge.Blueprint.AddExternalVariableNode.Transient` completed and garbage-marked its transient Blueprint fixtures while its global Undo records remained. A later `UnrealBridge.Material.InstanceLayerStack.Transient` called `GEditor->UndoTransaction()`, consumed the stale Blueprint transaction, and crashed in Kismet `FixSubObjectReferencesPostUndoRedo`.

The three tests that directly exercise `GEditor` Undo/Redo now establish a dedicated transaction boundary before coverage and clear it on scope exit. In tests with explicit garbage cleanup, the transaction reset guard executes first by LIFO order.

This is generic Unreal plugin repository/test hygiene; it contains no Oneiria paths, assets, or coordinator behavior.

## Verification
- `git check-ignore -v` matched probes under `Plugin/UnrealBridge/{Binaries,Intermediate,Saved}/`; authored Source/Config/Content paths remain visible
- `git diff --check` passed
- Python contract tests: 53/53 PASS
- Oneiria `Compile.bat`: all three changed C++ tests compiled and `UnrealEditor-UnrealBridge.dll` linked
- same fresh Editor, sequentially:
  - `UnrealBridge.Blueprint.AddExternalVariableNode.Transient`: 1/1 PASS, Queue Empty
  - `UnrealBridge.Material.InstanceLayerStack.Transient`: 1/1 PASS, Queue Empty, no crash
  - `UnrealBridge.Material.Parameters.ProductionSetReadAtomicityAndTransactions`: 1/1 PASS, Queue Empty
- independent reviews for both commits: P0/P1/P2 = 0/0/0

## Automation-session note
These tests intentionally clear global Editor Undo/Redo history. Run them in a dedicated/fresh automation Editor, not in an authoring session whose user undo history must be preserved.
