### PR TITLE
test: isolate editor transaction history

### DIFF
--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeAddExternalVariableNodeTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeAddExternalVariableNodeTests.cpp
@@ -91,6 +91,16 @@ bool FUnrealBridgeAddExternalVariableNodeTransientTest::RunTest(const FString& P
 	using namespace UnrealBridgeAddExternalVariableNodeTests;
 	(void)Parameters;
 
+	if (!TestNotNull(TEXT("Editor transaction subsystem is available"), GEditor))
+	{
+		return false;
+	}
+	// 自动化对象会在用例末尾销毁；先清空全局 Undo 栈，避免前序测试留下的事务取得本用例瞬态对象所有权。
+	// Automation objects are destroyed at test end; reset the global Undo stack first so earlier tests cannot own this fixture's transient objects.
+	GEditor->ResetTransaction(NSLOCTEXT(
+		"UnrealBridgeTests", "AddExternalVariableResetBefore",
+		"隔离外部变量节点测试事务 / Isolate external-variable-node test transactions"));
+
 	const FName BlueprintName = MakeUniqueObjectName(
 		GetTransientPackage(), UBlueprint::StaticClass(), TEXT("UB_AddExternalVariableNode_Consumer"));
 	UBlueprint* Blueprint = FKismetEditorUtilities::CreateBlueprint(
@@ -117,6 +127,17 @@ bool FUnrealBridgeAddExternalVariableNodeTransientTest::RunTest(const FString& P
 	ON_SCOPE_EXIT
 	{
 		CleanupTransientBlueprint(ProviderBlueprint);
+	};
+	// 该 guard 后声明、先于蓝图清理执行，确保 Undo 记录不会引用随后标垃圾的瞬态图对象。
+	// Declared after fixture cleanup guards, this runs first so no Undo record can reference graph objects that are about to be garbage-marked.
+	ON_SCOPE_EXIT
+	{
+		if (GEditor)
+		{
+			GEditor->ResetTransaction(NSLOCTEXT(
+				"UnrealBridgeTests", "AddExternalVariableResetAfter",
+				"清理外部变量节点测试事务 / Clear external-variable-node test transactions"));
+		}
 	};
 
 	const FName PrivateVariableName(TEXT("PrivateExternalValue"));

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialInstanceLayerStackTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialInstanceLayerStackTests.cpp
@@ -153,6 +153,16 @@ bool FUnrealBridgeMaterialInstanceLayerStackTransientTest::RunTest(const FString
 	using namespace UnrealBridgeMaterialInstanceLayerStackTests;
 	(void)Parameters;
 
+	if (!TestNotNull(TEXT("Editor transaction subsystem is available"), GEditor))
+	{
+		return false;
+	}
+	// Undo/Redo 断言只允许消费本用例创建的事务，不能依赖全局栈顶恰好来自材质操作。
+	// Undo/Redo assertions may consume only transactions created by this test, never whichever entry happens to be on the global stack.
+	GEditor->ResetTransaction(NSLOCTEXT(
+		"UnrealBridgeTests", "MaterialLayerStackResetBefore",
+		"隔离材质图层栈测试事务 / Isolate material-layer-stack test transactions"));
+
 	UPackage* TransientPackage = GetTransientPackage();
 	const bool bTransientPackageWasDirty = TransientPackage->IsDirty();
 	ON_SCOPE_EXIT
@@ -164,6 +174,17 @@ bool FUnrealBridgeMaterialInstanceLayerStackTransientTest::RunTest(const FString
 	ON_SCOPE_EXIT
 	{
 		CleanupFixture(Fixture);
+	};
+	// 在夹具标记为垃圾前先清空其 Undo 记录，防止后续测试触发悬空 Blueprint/材质引用。
+	// Clear this fixture's Undo records before garbage-marking it so later tests cannot traverse stale Blueprint/material references.
+	ON_SCOPE_EXIT
+	{
+		if (GEditor)
+		{
+			GEditor->ResetTransaction(NSLOCTEXT(
+				"UnrealBridgeTests", "MaterialLayerStackResetAfter",
+				"清理材质图层栈测试事务 / Clear material-layer-stack test transactions"));
+		}
 	};
 
 	const FString InstancePath = Fixture.Instance->GetPathName();

--- a/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialParameterTests.cpp
+++ b/Plugin/UnrealBridge/Source/UnrealBridge/Private/Tests/UnrealBridgeMaterialParameterTests.cpp
@@ -13,6 +13,7 @@
 #include "Materials/MaterialExpressionVectorParameter.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Misc/Paths.h"
+#include "Misc/ScopeExit.h"
 #include "UnrealBridgeMaterialLibrary.h"
 #include "UnrealBridgeMaterialParameterHelpers.h"
 #include "UObject/Package.h"
@@ -253,7 +254,26 @@ bool FUnrealBridgeMaterialParameterProductionTest::RunTest(const FString& Parame
 {
 	using namespace UnrealBridgeMaterialParameterTests;
 
+	if (!TestNotNull(TEXT("Editor transaction subsystem is available"), GEditor))
+	{
+		return false;
+	}
+	// 参数事务验证必须拥有独立的全局 Undo 边界，避免前序瞬态测试的记录被错误消费。
+	// Parameter transaction coverage needs an isolated global Undo boundary so records from earlier transient tests are never consumed.
+	GEditor->ResetTransaction(NSLOCTEXT(
+		"UnrealBridgeTests", "MaterialParameterResetBefore",
+		"隔离材质参数测试事务 / Isolate material-parameter test transactions"));
+
 	FTransientMaterialFixture Fixture;
+	ON_SCOPE_EXIT
+	{
+		if (GEditor)
+		{
+			GEditor->ResetTransaction(NSLOCTEXT(
+				"UnrealBridgeTests", "MaterialParameterResetAfter",
+				"清理材质参数测试事务 / Clear material-parameter test transactions"));
+		}
+	};
 	const FMaterialParameterInfo ScalarInfo(FName(TEXT("ScalarParam")));
 	const FMaterialParameterInfo SwitchInfo(FName(TEXT("StaticSwitchParam")));
 


### PR DESCRIPTION
## Summary
- isolate the three automation tests that directly exercise global Editor Undo/Redo
- reset transaction history before coverage and on scope exit
- ensure transaction records are cleared before transient Blueprint/material fixtures are garbage-marked
- leave product/runtime code unchanged

## Incident
In a full host-project automation run, `UnrealBridge.Blueprint.AddExternalVariableNode.Transient` completed and garbage-marked its transient Blueprint fixtures while global Undo records remained. Later, `UnrealBridge.Material.InstanceLayerStack.Transient` called `GEditor->UndoTransaction()`, consumed the stale `UnrealBridge: Add External Variable Node` transaction, and crashed in Kismet `FixSubObjectReferencesPostUndoRedo`.

The same two tests had passed independently, so the missing invariant was test-owned transaction isolation rather than product behavior.

## Verification
- `git diff --check` passed
- Python contract tests: 53/53 PASS
- Oneiria `Compile.bat`: all three changed C++ tests compiled and `UnrealEditor-UnrealBridge.dll` linked
- same fresh Editor, sequentially:
  - `UnrealBridge.Blueprint.AddExternalVariableNode.Transient`: 1/1 PASS, Queue Empty
  - `UnrealBridge.Material.InstanceLayerStack.Transient`: 1/1 PASS, Queue Empty, no crash
  - `UnrealBridge.Material.Parameters.ProductionSetReadAtomicityAndTransactions`: 1/1 PASS, Queue Empty
- independent review: P0/P1/P2 = 0/0/0

## Automation-session note
These tests intentionally clear global Editor Undo/Redo history. Run them in a dedicated/fresh automation Editor, not in an authoring session whose user undo history must be preserved.
